### PR TITLE
[DOCS] Incorrect directory path in Developer Documentation (Development Workflow - 3rd point) 

### DIFF
--- a/argilla/docs/community/developer.md
+++ b/argilla/docs/community/developer.md
@@ -64,7 +64,7 @@ Once your Codespace is ready:
 - **Backend Development**: Changes to `src/argilla_server/` or `src/extralit/` are automatically updated while Tilt is running
 - **Frontend Development**: For frontend changes:
   ```bash
-  cd argilla/argilla-frontend
+  cd argilla-frontend
   npm install
   npm run dev
   ```


### PR DESCRIPTION
# Description

There was an incorrect directory path mentioned in the Developer Documentation → Development Workflow (3rd point) section.

Incorrect: ``` cd argilla/argilla-frontend ```

Correct: ``` cd argilla-frontend ```

This fix updates the documentation to reflect the correct directory structure.

Closes #27

**Type of change**
- Documentation update

**How Has This Been Tested**
- Verified the correct directory structure in the repository.
- Cross-checked with the project’s file structure to ensure accuracy.

**Checklist**

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
