### PR TITLE
Update docker-compose.yml

### DIFF
--- a/.devcontainer/docker-compose/docker-compose.yml
+++ b/.devcontainer/docker-compose/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - elasticsearch
       - postgres
       - minio
+      - redis   # ✅ Add redis as dependency
     network_mode: host
       
   elasticsearch:
@@ -85,6 +86,14 @@ services:
       timeout: 10s
       retries: 3
     restart: unless-stopped
+
+  redis:  # ✅ Added redis service
+    image: redis:7.0
+    container_name: extralit-redis
+    ports:
+      - "6379:6379"
+    restart: unless-stopped
+    network_mode: host
 
 networks:
   argilla:


### PR DESCRIPTION
fix(docker-compose): Add missing Redis service to development configuration

Resolved Issue #33 by adding a Redis service to the docker-compose file. This enables successful startup of the development environment using `docker compose up -d elasticsearch redis`, matching the configuration used in CI and production.

- Added `redis` service using the official Redis 7.0 image
- Exposed port 6379 and set restart policy
- Included Redis in `devcontainer` dependencies

This ensures developers can work with Redis locally without facing service not found errors.
