### PR TITLE
Resolved Issue #33: Added Redis Service to docker-compose

### DIFF
--- a/.devcontainer/docker-compose/docker-compose.yml
+++ b/.devcontainer/docker-compose/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - elasticsearch
       - postgres
       - minio
+      - redis 
     network_mode: host
       
   elasticsearch:
@@ -85,6 +86,14 @@ services:
       timeout: 10s
       retries: 3
     restart: unless-stopped
+
+     redis:  
+    image: redis:7.0
+    container_name: extralit-redis
+    ports:
+      - "6379:6379"
+    restart: unless-stopped
+    network_mode: host
 
 networks:
   argilla:


### PR DESCRIPTION
Resolved Issue #33: Added Redis Service to docker-compose

Introduced a Redis service using the official Redis 7.0 image.

Exposed port 6379 and configured a restart policy for reliable service management.

Included Redis in the devcontainer dependencies to streamline the development setup.

This update ensures the development environment can be started with docker compose up -d elasticsearch redis, aligning it with the configuration used in CI and production.

Developers can now work locally without encountering service not found errors related to Redis.

