### PR TITLE
Refactor the `CONFIG_REPO_DIR` path from `.argilla/` to `.extralit/`

### DIFF
--- a/argilla-server/.env.dev
+++ b/argilla-server/.env.dev
@@ -1,7 +1,7 @@
 OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES # Needed by RQ to work with forked processes on MacOS
 ALEMBIC_CONFIG=src/argilla_server/alembic.ini
 ARGILLA_AUTH_SECRET_KEY=8VO7na5N/jQx+yP/N+HlE8q51vPdrxqlh6OzoebIyko= # With this we avoid using a different key every time the server is reloaded
-ARGILLA_DATABASE_URL=sqlite+aiosqlite:///${HOME}/.argilla/argilla-dev.db?check_same_thread=False
+ARGILLA_DATABASE_URL=sqlite+aiosqlite:///${HOME}/.extralit/argilla-dev.db?check_same_thread=False
 
 # S3 Configuration
 ARGILLA_S3_ENDPOINT=http://minio:9000

--- a/argilla-server/.env.test
+++ b/argilla-server/.env.test
@@ -1,2 +1,2 @@
-ARGILLA_DATABASE_URL=sqlite+aiosqlite:///${HOME}/.argilla/argilla-test.db?check_same_thread=False
+ARGILLA_DATABASE_URL=sqlite+aiosqlite:///${HOME}/.extralit/argilla-test.db?check_same_thread=False
 ARGILLA_REDIS_URL=redis://localhost:6379/1 # Using a different Redis database for testing

--- a/argilla-server/src/argilla_server/api/handlers/v1/models.py
+++ b/argilla-server/src/argilla_server/api/handlers/v1/models.py
@@ -1,8 +1,22 @@
+# Copyright 2024-present, Extralit Labs, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 from urllib.parse import urljoin
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from starlette.requests import Request
 from starlette.responses import StreamingResponse
 
@@ -11,30 +25,32 @@ from argilla_server.security import auth
 from argilla_server.settings import settings
 from argilla_server.errors import UnauthorizedError, BadRequestError
 
-_LOGGER = logging.getLogger("models")
+_LOGGER = logging.getLogger(__name__)
 
 router = APIRouter(tags=["models"])
 
 client = httpx.AsyncClient(timeout=10.0)
 
-@router.api_route("/models/{rest_of_path:path}", 
-                  methods=["GET", "POST", "PUT", "DELETE"], 
-                  response_class=StreamingResponse)
-async def proxy(request: Request, rest_of_path: str,
-                current_user: User = Depends(auth.get_current_user)):
+
+@router.api_route(
+    "/models/{rest_of_path:path}", methods=["GET", "POST", "PUT", "DELETE"], response_class=StreamingResponse
+)
+async def proxy(request: Request, rest_of_path: str, current_user: User = Depends(auth.get_current_user)):
     url = urljoin(settings.extralit_url, rest_of_path)
     params = dict(request.query_params)
 
-    _LOGGER.info('PROXY %s %s', url, params)
+    _LOGGER.info("PROXY %s %s", url, params)
 
-    if 'workspace' not in params or not params['workspace']:
+    if "workspace" not in params or not params["workspace"]:
         raise BadRequestError("`workspace` is required in query parameters")
 
     if current_user:
-        params['username'] = current_user.username
+        params["username"] = current_user.username
 
-        if current_user.role != "owner" and not await current_user.is_member_of_workspace_name(params['workspace']):
-            raise UnauthorizedError(f"{current_user.username} is not authorized to access workspace {params['workspace']}")
+        if current_user.role != "owner" and not await current_user.is_member_of_workspace_name(params["workspace"]):
+            raise UnauthorizedError(
+                f"{current_user.username} is not authorized to access workspace {params['workspace']}"
+            )
 
     if request.method == "GET":
         proxy_request = client.build_request("GET", url, params=params)
@@ -66,11 +82,13 @@ async def proxy(request: Request, rest_of_path: str,
 
     return StreamingResponse(stream_response(), media_type="text/event-stream")
 
+
 @router.on_event("startup")
 async def startup_event():
     global client
     if client is None:
         client = httpx.AsyncClient(timeout=10.0)
+
 
 @router.on_event("shutdown")
 async def shutdown():

--- a/argilla-server/src/argilla_server/contexts/hub.py
+++ b/argilla-server/src/argilla_server/contexts/hub.py
@@ -412,7 +412,7 @@ class HubDatasetExporter:
         hf_api = HfApi(token=token)
 
         with TemporaryDirectory() as temporary_directory:
-            argilla_directory = os.path.join(temporary_directory, ".argilla")
+            argilla_directory = os.path.join(temporary_directory, ".extralit")
             os.makedirs(argilla_directory)
 
             self._create_version_file(argilla_directory)

--- a/argilla-server/src/argilla_server/settings.py
+++ b/argilla-server/src/argilla_server/settings.py
@@ -179,7 +179,7 @@ class Settings(BaseSettings):
     @field_validator("home_path", mode="before")
     @classmethod
     def set_home_path_default(cls, home_path: str):
-        return home_path or os.path.join(Path.home(), ".argilla")
+        return home_path or os.path.join(Path.home(), ".extralit")
 
     @field_validator("base_url")
     @classmethod

--- a/argilla-v1/CHANGELOG.md
+++ b/argilla-v1/CHANGELOG.md
@@ -14,13 +14,11 @@ These are the section headers that we use:
 * "Security" in case of vulnerabilities.
 -->
 
-## [Extralit] [0.3.0](https://github.com/extralit/extralit/compare/v0.2.3...v0.3.0)
-
 
 ## [Argilla] [2.0.0rc1](https://github.com/argilla-io/argilla/compare/v1.29.0...v2.0.0rc1)
 
 > [!NOTE]
-> As per the release of our 2.0 SDK, this changelog is deprecated and will only contain potential bug fixes for the 1.x SDK, but it will not contain any new features. For the latest features and changes, please refer to the [2.0 SDK changelog](../argilla/CHANGELOG.md).
+> As per the release of our 2.0 SDK, this changelog is deprecated and will only contain potential bug fixes for the 1.x SDK, but it will not contain any new features. For the latest features and changes, please refer to the [2.0 SDK changelog](../extralit/CHANGELOG.md).
 
 ## [Argilla] [1.29.0](https://github.com/argilla-io/argilla/compare/v1.28.0...v1.29.0)
 

--- a/extralit/docs/getting_started/development_setup.md
+++ b/extralit/docs/getting_started/development_setup.md
@@ -158,7 +158,7 @@ cd argilla-server
 pdm install
 
 # Install client dependencies
-cd ../argilla
+cd ../extralit
 pdm install
 ```
 
@@ -180,7 +180,7 @@ Create a `.env.dev` file in the `argilla-server` directory with the following co
 ```
 ALEMBIC_CONFIG=src/argilla_server/alembic.ini
 ARGILLA_AUTH_SECRET_KEY=8VO7na5N/jQx+yP/N+HlE8q51vPdrxqlh6OzoebIyko=
-ARGILLA_DATABASE_URL=sqlite+aiosqlite:///${HOME}/.argilla/argilla-dev.db?check_same_thread=False
+ARGILLA_DATABASE_URL=sqlite+aiosqlite:///${HOME}/.extralit/argilla-dev.db?check_same_thread=False
 # Search engine configuration
 ARGILLA_SEARCH_ENGINE=elasticsearch
 ARGILLA_ELASTICSEARCH=http://localhost:9200
@@ -377,7 +377,7 @@ If database migrations fail:
 
 ```bash
 # Reset the database
-rm -rf ~/.argilla/argilla-dev.db
+rm -rf ~/.extralit/argilla-dev.db
 pdm run migrate
 ```
 

--- a/extralit/src/argilla/datasets/_io/_disk.py
+++ b/extralit/src/argilla/datasets/_io/_disk.py
@@ -1,4 +1,4 @@
-# Copyright 2024-present, Argilla, Inc.
+# Copyright 2024-present, Extralit Labs, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 import json
 import logging
@@ -35,7 +36,7 @@ class DiskImportExportMixin(ABC):
 
     _model: DatasetModel
     _DEFAULT_RECORDS_PATH = "records.json"
-    _DEFAULT_CONFIG_REPO_DIR = ".argilla"
+    _DEFAULT_CONFIG_REPO_DIR = ".extralit"
     _DEFAULT_SETTINGS_PATH = f"{_DEFAULT_CONFIG_REPO_DIR}/settings.json"
     _DEFAULT_DATASET_PATH = f"{_DEFAULT_CONFIG_REPO_DIR}/dataset.json"
     _DEFAULT_CONFIGURATION_FILES = [_DEFAULT_SETTINGS_PATH, _DEFAULT_DATASET_PATH]


### PR DESCRIPTION
This pull request includes updates to transition the project from "Argilla" to "Extralit" branding, alongside some minor code improvements and documentation updates. The most significant changes involve renaming directories, database paths, and configuration references, as well as improving code readability in specific files.

### Branding and Path Updates:
* Updated database paths in `.env.dev`, `.env.test`, and other configuration files to replace `.argilla` with `.extralit` (`argilla-server/.env.dev`, `argilla-server/.env.test`, `argilla-server/src/argilla_server/contexts/hub.py`, `argilla-server/src/argilla_server/settings.py`) [[1]](diffhunk://#diff-45cc92918f8fe6b1465f974964cb41410d3274ec320a932bc0418d12fbcd5582L4-R4) [[2]](diffhunk://#diff-8d731b302bbcffef8e75e65c219ce20b00a41fc91972bb77eebf7b62052f3202L1-R1) [[3]](diffhunk://#diff-de0f1c73e9644627cfd5e0b09bac6ed7501f1071027ffc0f970711cdecef173bL415-R415) [[4]](diffhunk://#diff-14997942195c205cafe7a587421adfb3b03eadcd02bb6cf1fd67e20be9eaff92L182-R182).
* Renamed internal constants and directories from `.argilla` to `.extralit` in `DiskImportExportMixin` and related paths (`extralit/src/argilla/datasets/_io/_disk.py`).

### Documentation Updates:
* Updated references in the development setup documentation to reflect the new "Extralit" branding and paths (`extralit/docs/getting_started/development_setup.md`) [[1]](diffhunk://#diff-988ff637dfccf57dff8c217caebcd7540d5fd121ad223cb70276fbd47589dccaL161-R161) [[2]](diffhunk://#diff-988ff637dfccf57dff8c217caebcd7540d5fd121ad223cb70276fbd47589dccaL183-R183) [[3]](diffhunk://#diff-988ff637dfccf57dff8c217caebcd7540d5fd121ad223cb70276fbd47589dccaL380-R380).
* Adjusted changelog links to point to the Extralit repository (`argilla-v1/CHANGELOG.md`).

### Code Improvements:
* Improved logging by replacing hardcoded logger names with `__name__` and refined the formatting of logging statements (`argilla-server/src/argilla_server/api/handlers/v1/models.py`).
* Reformatted the `proxy` route definition for better readability and consistency (`argilla-server/src/argilla_server/api/handlers/v1/models.py`).
* Added copyright headers for "Extralit Labs, Inc." in relevant files (`argilla-server/src/argilla_server/api/handlers/v1/models.py`, `extralit/src/argilla/datasets/_io/_disk.py`) [[1]](diffhunk://#diff-323d9c4014140ef85685163fde2da4f424eba8c3cae358fc1255b3c37ba7b5bfR1-R19) [[2]](diffhunk://#diff-c4b464cc17491a2f622b3656499793bbeb293d7c3c0b67f07991a928e54805f2L1-R1).

### Miscellaneous:
* Added missing blank lines for better code organization (`argilla-server/src/argilla_server/api/handlers/v1/models.py`, `extralit/src/argilla/datasets/_io/_disk.py`) [[1]](diffhunk://#diff-323d9c4014140ef85685163fde2da4f424eba8c3cae358fc1255b3c37ba7b5bfR85-R92) [[2]](diffhunk://#diff-c4b464cc17491a2f622b3656499793bbeb293d7c3c0b67f07991a928e54805f2R15).