### PR TITLE
[FIX] DocumentAPI to query by params and return multiple documents & fix PDF file fetching

### DIFF
--- a/extralit-frontend/CHANGELOG.md
+++ b/extralit-frontend/CHANGELOG.md
@@ -14,6 +14,10 @@ These are the section headers that we use:
 * "Security" in case of vulnerabilities.
 -->
 
+## [Extralit] [0.6.1](https://github.com/extralit/extralit/compare/v0.5.0...v0.6.1)
+### Changed
+- Refactored the frontend to use a single fetchDocument method that queries documents by any identifier and workspace, replacing the previous fetchDocumentByID and fetchDocumentByPubmedID methods. The view model and use case now expect and handle the new API response format
+
 ## [Extralit] [0.6.0](https://github.com/extralit/extralit/compare/v0.4.1...v0.6.0)
 
 ### Added

--- a/extralit-frontend/components/base/base-pdf-viewer/PDFViewer.vue
+++ b/extralit-frontend/components/base/base-pdf-viewer/PDFViewer.vue
@@ -56,21 +56,6 @@ export default {
     };
   },
 
-  mounted() {
-    window.addEventListener("hashchange", this.onHashChange);
-    this.onHashChange(); // Call on component mount to handle initial hash
-  },
-
-  methods: {
-    onHashChange() {
-      const hash = window.location.hash.substring(1); // Remove the '#' from the hash
-      const [key, value] = hash.split(".");
-      if (key === "page_number" && !isNaN(value)) {
-        this.currentPageNumber = Number(value);
-      }
-    },
-  },
-
   errorCaptured(err, component, info) {
     this.error = err;
     console.error(`Error caught from ${component}: ${err}`);

--- a/extralit-frontend/components/base/base-pdf-viewer/PDFViewer.vue
+++ b/extralit-frontend/components/base/base-pdf-viewer/PDFViewer.vue
@@ -19,7 +19,7 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
 import { PDFView } from "@jonnytran/vue-pdf-viewer";
 
 export default {
@@ -44,8 +44,8 @@ export default {
   },
 
   watch: {
-    pageNumber(newPageNumber) {
-      this.currentPageNumber = newPageNumber;
+    pageNumber(newPageNumber: Number | String) {
+      this.currentPageNumber = newPageNumber ? Number(newPageNumber) : 1;
     },
   },
 

--- a/extralit-frontend/components/features/annotation/container/mode/useDocumentViewModel.ts
+++ b/extralit-frontend/components/features/annotation/container/mode/useDocumentViewModel.ts
@@ -6,10 +6,12 @@ import { Segment } from "@/v1/domain/entities/document/Document";
 import { useDataset } from "@/v1/infrastructure/storage/DatasetStorage";
 import { waitForAsyncValue } from "@/v1/infrastructure/services/useWait";
 import { useNotifications } from "~/v1/infrastructure/services/useNotifications";
+import { useWorkspaces } from "~/v1/infrastructure/storage/WorkspaceStorage";
 
 export const useDocumentViewModel = (props: { record: any }) => {
   const notification = useNotifications();
   const getDocument = useResolve(GetDocumentByIdUseCase);
+  const { state: workspaces } = useWorkspaces();
   const { state: dataset } = useDataset();
   const { state: document, set: setDocument, clear: clearDocument } = useDocument();
   const isLoading = ref(false);
@@ -19,28 +21,38 @@ export const useDocumentViewModel = (props: { record: any }) => {
   });
   const hasDocument = computed(() => {
     return (
-      props.record.metadata === null || props.record.metadata?.doc_id != null || props.record.metadata?.pmid != null
+      props.record.metadata === null || props.record.metadata?.reference != null || props.record.metadata?.pmid != null
     );
   });
 
-  const fetchDocumentByID = async (id: string) => {
+  const fetchDocument = async (metadata: any) => {
     try {
-      await getDocument.setDocumentByID(id);
-    } catch (e) {
-      notification.notify({
-        message: `Error fetching document with ID ${id}`,
-        type: "danger",
-      });
-      clearDocument();
-    }
-  };
+      await waitForAsyncValue(() => workspaces.selectedWorkspace?.id);
 
-  const fetchDocumentByPubmedID = async (pmid: string) => {
-    try {
-      await getDocument.setDocumentByPubmedID(pmid);
+      const params: {
+        workspace_id: string;
+        doc_id?: string;
+        pmid?: string;
+        doi?: string;
+        reference?: string;
+      } = { workspace_id: workspaces.selectedWorkspace!.id };
+
+      if (metadata?.reference) params.reference = metadata.reference;
+      if (metadata?.doc_id) params.doc_id = metadata.doc_id;
+      if (metadata?.pmid) params.pmid = metadata.pmid;
+      if (metadata?.doi) params.doi = metadata.doi;
+
+      // Ensure at least one identifier is provided
+      if (Object.keys(params).length === 0) {
+        throw new Error("No valid document identifier found in metadata");
+      }
+
+      await getDocument.setDocument(params);
     } catch (e) {
+      const identifier = metadata?.pmid || metadata?.doi || metadata?.doc_id || metadata?.reference || "unknown";
+      console.error(`Error fetching document with identifier "${identifier}":`, e);
       notification.notify({
-        message: `Error fetching document with pmid "${pmid}"`,
+        message: `Error fetching document with identifier "${identifier}"`,
         type: "danger",
       });
       clearDocument();
@@ -48,13 +60,13 @@ export const useDocumentViewModel = (props: { record: any }) => {
   };
 
   const updateDocument = async (metadata: any) => {
-    if (metadata?.pmid != null) {
-      if (document.pmid !== metadata.pmid) {
-        fetchDocumentByPubmedID(metadata.pmid);
-      }
+    if (metadata?.pmid != null && document.pmid !== metadata.pmid) {
+      fetchDocument(metadata);
+    } else if (metadata?.doi != null && document.doi !== metadata.doi) {
+      fetchDocument(metadata);
     } else if (metadata?.doc_id != null && document.id !== metadata.doc_id) {
-      fetchDocumentByID(metadata.doc_id);
-    } else if (!metadata?.pmid && !metadata?.doc_id && hasDocumentLoaded.value) {
+      fetchDocument(metadata);
+    } else if (!metadata?.pmid && !metadata?.doi && !metadata?.doc_id && hasDocumentLoaded.value) {
       clearDocument();
     }
 
@@ -107,8 +119,6 @@ export const useDocumentViewModel = (props: { record: any }) => {
 
   return {
     document,
-    fetchDocumentByID,
-    fetchDocumentByPubmedID,
     fetchDocumentSegments,
     focusDocumentPageNumber,
     clearDocument,

--- a/extralit-frontend/v1/domain/entities/document/Document.ts
+++ b/extralit-frontend/v1/domain/entities/document/Document.ts
@@ -6,19 +6,19 @@ export class Segment {
 		public readonly header: string | null,
 		public readonly page_number: number | null,
 		public readonly type: string | null,
-	) {}
+	) { }
 
 	public static getDescription(segment: Segment): string {
-			let segmentDescription = Object.entries(segment)
-					.filter(([key, value]) => !['header', 'doc_id'].includes(key))
-					.map(([key, value]) => `${key}: ${value}`)
-					.join('\n');
-			return segmentDescription;
+		let segmentDescription = Object.entries(segment)
+			.filter(([key, value]) => !['header', 'doc_id'].includes(key))
+			.map(([key, value]) => `${key}: ${value}`)
+			.join('\n');
+		return segmentDescription;
 	}
 }
 
 export interface Segments {
-  items: Segment[];
+	items: Segment[];
 }
 
 export class Document {
@@ -27,6 +27,7 @@ export class Document {
 		public readonly url?: string,
 		public readonly file_name?: string,
 		public readonly pmid?: string,
+		public readonly doi?: string,
 		public readonly page_number?: number | string,
 		public reference?: string,
 		public segments?: Segment[],

--- a/extralit-frontend/v1/domain/usecases/get-document-by-id-use-case.ts
+++ b/extralit-frontend/v1/domain/usecases/get-document-by-id-use-case.ts
@@ -8,16 +8,26 @@ export class GetDocumentByIdUseCase {
     private readonly documentStorage: IDocumentStorage
   ) {}
 
-  async setDocumentByID(id: string) {
-    const document = await this.documentRepository.getDocumentById(id);
+  async setDocument(params: {
+    workspace_id: string;
+    doc_id?: string;
+    pmid?: string;
+    doi?: string;
+    reference?: string;
+  }) {
+    const documents = await this.documentRepository.getDocuments(params);
 
-    this.documentStorage.set(document);
-  }
+    if (documents.length === 0) {
+      throw new Error("No documents found with the provided criteria");
+    }
 
-  async setDocumentByPubmedID(id: string) {
-    const document = await this.documentRepository.getDocumentByPubmedID(id);
+    // For now, we'll use the first document found
+    // In the future, you might want to add logic to handle multiple documents
+    if (documents.length > 1) {
+      console.warn(`Multiple documents found (${documents.length}). Using the first one.`);
+    }
 
-    this.documentStorage.set(document);
+    this.documentStorage.set(documents[0]);
   }
 
   async setSegments(workspace: string, reference: string): Promise<Segment[]> {

--- a/extralit-frontend/v1/infrastructure/repositories/DocumentRepository.ts
+++ b/extralit-frontend/v1/infrastructure/repositories/DocumentRepository.ts
@@ -3,25 +3,29 @@ import { Document, Segment, Segments } from "@/v1/domain/entities/document/Docum
 
 const DOCUMENT_API_ERRORS = {
   ERROR_FETCHING_DOCUMENT: "ERROR_FETCHING_DOCUMENT",
+  ERROR_FETCHING_SEGMENTS: "ERROR_FETCHING_SEGMENTS",
 };
 
 export class DocumentRepository {
   constructor(private readonly axios: NuxtAxiosInstance) {}
 
-  async getDocumentByPubmedID(pmid: string): Promise<Document> {
+  async getDocuments(params: {
+    workspace_id: string;
+    doc_id?: string;
+    pmid?: string;
+    doi?: string;
+    reference?: string;
+  }): Promise<Document[]> {
     try {
-      const { data } = await this.axios.get<Document>(`/v1/documents/by-pmid/${pmid}`);
-      return data;
-    } catch (error) {
-      throw {
-        response: DOCUMENT_API_ERRORS.ERROR_FETCHING_DOCUMENT,
-      };
-    }
-  }
+      const queryParams = Object.fromEntries(Object.entries(params).filter(([_, value]) => value !== undefined));
 
-  async getDocumentById(id: string): Promise<Document> {
-    try {
-      const { data } = await this.axios.get<Document>(`/v1/documents/by-id/${id}`);
+      if (Object.keys(queryParams).length === 0) {
+        throw new Error("At least one identifier parameter must be provided");
+      }
+
+      const { data } = await this.axios.get<Document[]>("/v1/documents", {
+        params: queryParams,
+      });
       return data;
     } catch (error) {
       throw {
@@ -39,7 +43,7 @@ export class DocumentRepository {
       return data.items;
     } catch (error) {
       throw {
-        response: DOCUMENT_API_ERRORS.ERROR_FETCHING_DOCUMENT,
+        response: DOCUMENT_API_ERRORS.ERROR_FETCHING_SEGMENTS,
       };
     }
   }

--- a/extralit-server/CHANGELOG.md
+++ b/extralit-server/CHANGELOG.md
@@ -14,6 +14,11 @@ These are the section headers that we use:
 * "Security" in case of vulnerabilities.
 -->
 
+## [Extralit] [0.6.1](https://github.com/extralit/extralit/compare/v0.5.0...v0.6.1)
+
+### Changed
+- Replaced separate /documents/by-id/{id} and /documents/by-pmid/{pmid} endpoints with a single /documents endpoint that accepts workspace_id and one or more identifiers (id, pmid, doi, reference), returning a list of matching documents
+
 ## [Extralit] [0.6.0](https://github.com/extralit/extralit/compare/v0.5.0...v0.6.0)
 
 ### Added

--- a/extralit-server/src/extralit_server/api/handlers/v1/documents.py
+++ b/extralit-server/src/extralit_server/api/handlers/v1/documents.py
@@ -15,9 +15,9 @@
 import json
 import logging
 from uuid import UUID, uuid4
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Optional
 
-from fastapi import APIRouter, Body, Depends, File, Form, HTTPException, UploadFile, Path, status, Security
+from fastapi import APIRouter, Body, Depends, File, Form, HTTPException, UploadFile, Path, status, Security, Query
 from minio import Minio
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
@@ -71,7 +71,7 @@ async def add_document(
         file_url = files.put_document_file(
             client=client,
             workspace_name=workspace.name,
-            document_id=document_create.id,
+            document_id=document_create.id,  # type: ignore[arg-type]
             file_data=file_data_bytes,
             filename=file_data.filename or "",
             metadata=document_create.dict(include={"file_name": True, "pmid": True, "doi": True}),
@@ -106,58 +106,57 @@ async def add_document(
     return document.id
 
 
-@router.get("/documents/by-pmid/{pmid}", response_model=DocumentListItem)
-async def get_document_by_pmid(
-    *, db: AsyncSession = Depends(get_async_db), pmid: str, current_user: User = Security(auth.get_current_user)
-):
-    if pmid is None or not isinstance(pmid, str) or not pmid.isnumeric():
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Document with pmid `{pmid}` not found",
-        )
-
-    query = await db.execute(select(Document).where(Document.pmid == pmid))
-    await authorize(current_user, DocumentPolicy.get())
-
-    documents = query.fetchone()
-    if documents is None or len(documents) == 0:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Document with pmid `{pmid}` not found",
-        )
-
-    document: Document = documents[0]
-    return DocumentListItem.model_validate(document)
-
-
-@router.get("/documents/by-id/{id}", response_model=DocumentListItem)
-async def get_document_by_id(
+@router.get(
+    "/documents", response_model=List[DocumentListItem], description="Get documents by ID, PMID, DOI, or reference."
+)
+async def get_document(
     *,
-    id: UUID = Path(..., title="The UUID of the document to get"),
+    workspace_id: UUID = Query(..., description="Workspace ID"),
+    id: Optional[UUID] = Query(None, description="Document ID"),
+    reference: Optional[str] = Query(None, description="Document reference"),
+    pmid: Optional[str] = Query(None, description="PubMed ID"),
+    doi: Optional[str] = Query(None, description="DOI"),
     db: AsyncSession = Depends(get_async_db),
     current_user: User = Security(auth.get_current_user),
-):
-    if id is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Document with id `{id}` not found",
-        )
-
-    query = await db.execute(select(Document).where(Document.id == id))
+) -> List[DocumentListItem]:
     await authorize(current_user, DocumentPolicy.get())
 
-    documents = query.fetchone()
-    if documents is None or len(documents) == 0:
+    if not any([id, pmid, doi, reference]):
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Document with id `{id}` not found",
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="At least one of id, pmid, doi, or reference must be provided",
         )
 
-    document: Document = documents[0]
-    return DocumentListItem.model_validate(document)
+    documents = await imports.find_existing_documents(
+        db=db,
+        workspace_id=workspace_id,
+        document_id=id,
+        pmid=pmid,
+        doi=doi,
+        reference=reference,
+    )
+
+    if not documents:
+        # If we still haven't found anything, raise 404
+        search_criteria = []
+        if id:
+            search_criteria.append(f"id={id}")
+        if pmid:
+            search_criteria.append(f"pmid={pmid}")
+        if doi:
+            search_criteria.append(f"doi={doi}")
+        if reference:
+            search_criteria.append(f"reference={reference}")
+
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No documents found with criteria: {', '.join(search_criteria)} in workspace {workspace_id}",
+        )
+
+    return documents
 
 
-@router.patch("/documents/{id}", response_model=DocumentListItem)
+@router.patch("/documents/{id}", response_model=DocumentListItem, description="Update a document by ID.")
 async def update_document(
     *,
     id: UUID = Path(..., title="The UUID of the document to update"),
@@ -165,7 +164,6 @@ async def update_document(
     db: AsyncSession = Depends(get_async_db),
     current_user: User = Security(auth.get_current_user),
 ):
-    """Update a document by ID."""
     # First, get the document to ensure it exists and check permissions
     query = await db.execute(select(Document).where(Document.id == id))
     result = query.fetchone()

--- a/extralit-server/src/extralit_server/api/handlers/v1/files.py
+++ b/extralit-server/src/extralit_server/api/handlers/v1/files.py
@@ -72,7 +72,12 @@ async def put_file(
 
     try:
         response = files.put_object(
-            client, bucket, object, data=file.file, size=file.size, content_type=file.content_type
+            client,
+            bucket,
+            object,
+            data=file.file,
+            size=file.size,  # type: ignore
+            content_type=file.content_type,  # type: ignore
         )
         return response
     except S3Error as se:

--- a/extralit-server/src/extralit_server/api/schemas/v1/files.py
+++ b/extralit-server/src/extralit_server/api/schemas/v1/files.py
@@ -44,10 +44,10 @@ class ObjectMetadata(BaseModel):
         return v
 
     @classmethod
-    def from_minio_object(cls, minio_object: Object):
+    def from_minio_object(cls, minio_object: Object) -> "ObjectMetadata":
         return cls(
             bucket_name=minio_object.bucket_name,
-            object_name=minio_object.object_name,
+            object_name=minio_object.object_name or "",
             last_modified=minio_object.last_modified,
             is_latest=None if minio_object.is_latest is None else minio_object.is_latest.lower() == "true",
             etag=minio_object.etag,
@@ -58,7 +58,7 @@ class ObjectMetadata(BaseModel):
         )
 
     @classmethod
-    def from_minio_write_response(cls, write_result: ObjectWriteResult):
+    def from_minio_write_response(cls, write_result: ObjectWriteResult) -> "ObjectMetadata":
         return cls(
             bucket_name=write_result.bucket_name,
             object_name=write_result.object_name,
@@ -76,10 +76,10 @@ class ListObjectsResponse(BaseModel):
     objects: Iterable[ObjectMetadata] = Field(default_factory=list)
 
     def __len__(self) -> int:
-        return len(self.objects)
+        return len(self.objects)  # type: ignore
 
     def __getitem__(self, index) -> ObjectMetadata:
-        return self.objects[index]
+        return self.objects[index]  # type: ignore
 
     def __iter__(self):
         return iter(self.objects)
@@ -114,14 +114,14 @@ class ListObjectsResponse(BaseModel):
 
 class FileObjectResponse(BaseModel):
     response: HTTPResponse
-    metadata: Optional[ObjectMetadata]
+    metadata: ObjectMetadata
     versions: Optional[ListObjectsResponse]
 
     class Config:
         arbitrary_types_allowed = True
 
     @property
-    def version_tag(self) -> str:
+    def version_tag(self) -> Optional[str]:
         if not self.metadata or not self.versions:
             return ""
         else:

--- a/extralit-server/src/extralit_server/contexts/files.py
+++ b/extralit-server/src/extralit_server/contexts/files.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any, BinaryIO, Dict, List, Optional, Union
 from urllib.parse import urlparse
 from uuid import UUID
+from minio.datatypes import Object
 from urllib3 import HTTPResponse
 
 from fastapi import HTTPException
@@ -83,8 +84,8 @@ class LocalFileStorage:
         data: Union[BinaryIO, bytes],
         length: Optional[int] = None,
         content_type: Optional[str] = None,
-        part_size: int = None,
-        metadata: Dict[str, Any] = None,
+        part_size: Optional[int] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> ObjectWriteResult:
         # Ensure bucket exists
         bucket_path = self._get_bucket_path(bucket_name)
@@ -126,7 +127,7 @@ class LocalFileStorage:
             object_name=object_name,
             version_id=version_id,
             etag=content_hash,
-            http_headers={},
+            http_headers={},  # type: ignore
             last_modified=None,
             location=None,
         )
@@ -153,7 +154,7 @@ class LocalFileStorage:
         with open(meta_path, "r") as f:
             json.load(f)
 
-        return HTTPResponse(body=io.BytesIO(content), preload_content=False)
+        return HTTPResponse(body=io.BytesIO(content), preload_content=False)  # type: ignore
 
     def stat_object(self, bucket_name: str, object_name: str, version_id: Optional[str] = None) -> ObjectMetadata:
         if version_id:
@@ -177,15 +178,13 @@ class LocalFileStorage:
 
         stats = path.stat()
 
-        last_modified = datetime.fromtimestamp(stats.st_mtime)
-
         return ObjectMetadata(
             bucket_name=bucket_name,
             object_name=object_name,
             version_id=version_id or metadata.get("version_id"),
             etag=metadata.get("etag"),
             size=stats.st_size,
-            last_modified=last_modified,
+            last_modified=datetime.fromtimestamp(stats.st_mtime),
             metadata=metadata,
             content_type=metadata.get("content_type", "application/octet-stream"),
         )
@@ -235,6 +234,7 @@ class LocalFileStorage:
         if start_after:
             files = [f for f in files if str(f.relative_to(bucket_path)) > start_after]
 
+        result = []
         for file_path in files:
             object_name = str(file_path.relative_to(bucket_path))
             stats = file_path.stat()
@@ -252,25 +252,27 @@ class LocalFileStorage:
                 object_name=object_name,
                 etag=metadata.get("etag"),
                 size=stats.st_size,
-                last_modified=stats.st_mtime,
+                last_modified=datetime.fromtimestamp(stats.st_mtime),
                 metadata=metadata,
                 content_type=metadata.get("content_type", "application/octet-stream"),
                 version_id=metadata.get("version_id") if include_version else None,
             )
 
-            yield obj
+            result.append(obj)
+
+        return result
 
 
 def get_minio_client() -> Optional[Union[Minio, LocalFileStorage]]:
     if None in [settings.s3_endpoint, settings.s3_access_key, settings.s3_secret_key]:
         # Use local file system storage if S3 settings are not provided
-        local_storage_path = os.path.join(settings.home_path, "storage")
+        local_storage_path = os.path.join(settings.home_path, "storage")  # type: ignore
         _LOGGER.info(f"Using local file storage at: {local_storage_path}")
         return LocalFileStorage(local_storage_path)
 
     try:
         parsed_url = urlparse(settings.s3_endpoint)
-        hostname = parsed_url.hostname
+        hostname: str = str(parsed_url.hostname)
         port = parsed_url.port
 
         if hostname is None:
@@ -318,10 +320,12 @@ def list_objects(
     recursive=True,
     start_after: Optional[str] = None,
 ) -> ListObjectsResponse:
-    objects = client.list_objects(
+    objects: List[ObjectMetadata | Object] = client.list_objects(  # type: ignore
         bucket, prefix=prefix, recursive=recursive, include_version=include_version, start_after=start_after
     )
-    objects = [ObjectMetadata.from_minio_object(obj) for obj in objects]
+    objects: List[ObjectMetadata] = [
+        obj if isinstance(obj, ObjectMetadata) else ObjectMetadata.from_minio_object(obj) for obj in objects
+    ]
     return ListObjectsResponse(objects=objects)
 
 
@@ -368,9 +372,9 @@ def put_object(
     bucket: str,
     object: str,
     data: Union[BinaryIO, bytes, str],
-    content_type: str = None,
-    size: int = None,
-    metadata: Dict[str, Any] = None,
+    size: int,
+    content_type: str = "application/octet-stream",
+    metadata: Optional[Dict[str, Any]] = None,
     part_size: int = 100 * 1024 * 1024,
 ) -> ObjectMetadata:
     if isinstance(data, bytes):
@@ -391,7 +395,7 @@ def put_object(
             content_type=content_type,
             length=size,
             part_size=part_size,
-            metadata=metadata,
+            metadata=metadata or {},
         )
 
         return ObjectMetadata.from_minio_write_response(response)
@@ -512,7 +516,8 @@ def delete_bucket(client: Union[Minio, LocalFileStorage], workspace_name: str):
             obj_list = list(objects)
             for obj in obj_list:
                 try:
-                    client.remove_object(workspace_name, obj.object_name, version_id=obj.version_id)
+                    if obj.object_name is not None:
+                        client.remove_object(workspace_name, obj.object_name, version_id=obj.version_id)
                 except S3Error as remove_err:
                     _LOGGER.warning(
                         f"Error removing object {obj.object_name} (version: {obj.version_id}) during bucket delete: {remove_err}"

--- a/extralit-server/src/extralit_server/contexts/files.py
+++ b/extralit-server/src/extralit_server/contexts/files.py
@@ -357,7 +357,11 @@ def get_object(
         else:
             versions = None
 
-        return FileObjectResponse(response=obj, metadata=stat, versions=versions)
+        return FileObjectResponse(
+            response=obj,
+            metadata=stat if isinstance(stat, ObjectMetadata) else ObjectMetadata.from_minio_object(stat),
+            versions=versions,
+        )
 
     except S3Error as se:
         _LOGGER.error(f"Error getting object {object} from bucket {bucket}: {se}")

--- a/extralit-server/tests/unit/api/handlers/v1/test_documents.py
+++ b/extralit-server/tests/unit/api/handlers/v1/test_documents.py
@@ -129,22 +129,90 @@ async def test_get_document_by_pmid(async_client: "AsyncClient", db: "AsyncSessi
     workspace = await WorkspaceFactory.create()
     document = await DocumentFactory.create(pmid="123456", workspace=workspace, workspace_id=workspace.id)
 
-    response = await async_client.get(f"/api/v1/documents/by-pmid/{document.pmid}", headers=owner_auth_header)
+    response = await async_client.get(
+        "/api/v1/documents",
+        params={"pmid": document.pmid, "workspace_id": str(workspace.id)},
+        headers=owner_auth_header,
+    )
 
     assert response.status_code == 200
-    assert response.json()["pmid"] == document.pmid
+    response_data = response.json()
+    assert isinstance(response_data, list)
+    assert len(response_data) == 1
+    assert response_data[0]["pmid"] == document.pmid
 
 
 @pytest.mark.asyncio
 @pytest.mark.skip(reason="'coroutine' object has no attribute 'id'")
 async def test_get_document_by_id(async_client: AsyncClient, db: AsyncSession, owner_auth_header: dict):
-    document = await DocumentFactory.create()
+    workspace = await WorkspaceFactory.create()
+    document = await DocumentFactory.create(workspace=workspace, workspace_id=workspace.id)
 
-    response = await async_client.get(f"/api/v1/documents/by-id/{document.id}", headers=owner_auth_header)
+    response = await async_client.get(
+        "/api/v1/documents",
+        params={"id": str(document.id), "workspace_id": str(workspace.id)},
+        headers=owner_auth_header,
+    )
 
     assert response.status_code == 200
-    response_json = response.json()
-    assert response_json["id"] == str(document.id)
+    response_data = response.json()
+    assert isinstance(response_data, list)
+    assert len(response_data) == 1
+    assert response_data[0]["id"] == str(document.id)
+
+
+@pytest.mark.asyncio
+async def test_get_document_by_doi(async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict):
+    workspace = await WorkspaceFactory.create()
+    document = await DocumentFactory.create(doi="10.1234/test.doi", workspace=workspace, workspace_id=workspace.id)
+
+    response = await async_client.get(
+        "/api/v1/documents", params={"doi": document.doi, "workspace_id": str(workspace.id)}, headers=owner_auth_header
+    )
+
+    assert response.status_code == 200
+    response_data = response.json()
+    assert isinstance(response_data, list)
+    assert len(response_data) == 1
+    assert response_data[0]["doi"] == document.doi
+
+
+@pytest.mark.asyncio
+async def test_get_document_by_reference(async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict):
+    workspace = await WorkspaceFactory.create()
+    document = await DocumentFactory.create(reference="test_ref_123", workspace=workspace, workspace_id=workspace.id)
+
+    response = await async_client.get(
+        "/api/v1/documents",
+        params={"reference": document.reference, "workspace_id": str(workspace.id)},
+        headers=owner_auth_header,
+    )
+
+    assert response.status_code == 200
+    response_data = response.json()
+    assert isinstance(response_data, list)
+    assert len(response_data) == 1
+    assert response_data[0]["reference"] == document.reference
+
+
+@pytest.mark.asyncio
+async def test_get_document_workspace_id_only(async_client: "AsyncClient", owner_auth_header: dict):
+    """Test that requesting documents with only workspace_id returns a 400 error."""
+    response = await async_client.get(
+        "/api/v1/documents", params={"workspace_id": "123e4567-e89b-12d3-a456-426614174000"}, headers=owner_auth_header
+    )
+
+    assert response.status_code == 400
+    assert "At least one of id, pmid, doi, or reference must be provided" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_get_document_no_parameters(async_client: "AsyncClient", owner_auth_header: dict):
+    """Test that requesting documents without any parameters returns a 400 error."""
+    response = await async_client.get("/api/v1/documents", headers=owner_auth_header)
+
+    assert response.status_code == 400
+    assert "At least one of id, pmid, doi, or reference must be provided" in response.json()["detail"]
 
 
 @pytest.mark.skip(reason="Document delete API is failing with 500 error")

--- a/extralit-server/tests/unit/api/handlers/v1/test_documents.py
+++ b/extralit-server/tests/unit/api/handlers/v1/test_documents.py
@@ -208,11 +208,11 @@ async def test_get_document_workspace_id_only(async_client: "AsyncClient", owner
 
 @pytest.mark.asyncio
 async def test_get_document_no_parameters(async_client: "AsyncClient", owner_auth_header: dict):
-    """Test that requesting documents without any parameters returns a 400 error."""
+    """Test that requesting documents without any parameters returns a 422 validation error."""
     response = await async_client.get("/api/v1/documents", headers=owner_auth_header)
 
-    assert response.status_code == 400
-    assert "At least one of id, pmid, doi, or reference must be provided" in response.json()["detail"]
+    assert response.status_code == 422
+    # FastAPI validation error for missing required parameter workspace_id
 
 
 @pytest.mark.skip(reason="Document delete API is failing with 500 error")

--- a/extralit/CHANGELOG.md
+++ b/extralit/CHANGELOG.md
@@ -14,6 +14,10 @@ These are the section headers that we use:
 * "Security" in case of vulnerabilities.
 -->
 
+## [Extralit] [0.6.1](https://github.com/extralit/extralit/compare/v0.5.0...v0.6.1)
+### Changed
+- Updated backend document fetching logic to use the new unified endpoint, including improved input validation and error messages
+
 ## [Extralit] [0.6.0](https://github.com/extralit/extralit/compare/v0.5.0...v0.6.0)
 
 ### Added

--- a/extralit/src/extralit/_api/_documents.py
+++ b/extralit/src/extralit/_api/_documents.py
@@ -57,22 +57,35 @@ class DocumentsAPI(ResourceAPI):
         return model
 
     @api_error_handler
-    def get(self, id: UUID) -> "DocumentModel":
-        """Get a document by ID.
+    def get(self, params: dict) -> "DocumentModel":
+        """Get a document using multiple search criteria.
 
         Args:
-            id: The document ID.
+            params: Dictionary containing any combination of:
+                - workspace_id: Workspace ID (required)
+                - id: Document ID
+                - pmid: PubMed ID
+                - doi: DOI
+                - reference: Document reference
 
         Returns:
             The document model.
         """
         from extralit._models._documents import DocumentModel
 
-        url = f"/api/v1/documents/by-id/{id}"
-        response = self.http_client.get(url=url)
+        url = "/api/v1/documents"
+        response = self.http_client.get(url=url, params=params)
         response.raise_for_status()
 
-        doc_data = response.json()
+        doc_data_list = response.json()
+
+        if not doc_data_list:
+            raise ValueError("No documents found with the provided criteria")
+
+        if len(doc_data_list) > 1:
+            print(f"Warning: Multiple documents found ({len(doc_data_list)}). Using the first one.")
+
+        doc_data = doc_data_list[0]
         return DocumentModel(
             id=doc_data.get("id"),
             workspace_id=doc_data.get("workspace_id"),
@@ -83,35 +96,7 @@ class DocumentsAPI(ResourceAPI):
             doi=doc_data.get("doi"),
             inserted_at=doc_data.get("inserted_at"),
             updated_at=doc_data.get("updated_at"),
-        )
-
-    @api_error_handler
-    def get_by_pmid(self, pmid: str) -> "DocumentModel":
-        """Get a document by PMID.
-
-        Args:
-            pmid: The PubMed ID.
-
-        Returns:
-            The document model.
-        """
-        from extralit._models._documents import DocumentModel
-
-        url = f"/api/v1/documents/by-pmid/{pmid}"
-        response = self.http_client.get(url=url)
-        response.raise_for_status()
-
-        doc_data = response.json()
-        return DocumentModel(
-            id=doc_data.get("id"),
-            workspace_id=doc_data.get("workspace_id"),
-            file_name=doc_data.get("file_name"),
-            reference=doc_data.get("reference"),
-            url=doc_data.get("url"),
-            pmid=doc_data.get("pmid"),
-            doi=doc_data.get("doi"),
-            inserted_at=doc_data.get("inserted_at"),
-            updated_at=doc_data.get("updated_at"),
+            file_path=None,
         )
 
     @api_error_handler
@@ -142,6 +127,7 @@ class DocumentsAPI(ResourceAPI):
                 doi=doc_data.get("doi"),
                 inserted_at=doc_data.get("inserted_at"),
                 updated_at=doc_data.get("updated_at"),
+                file_path=None,
             )
             documents.append(doc)
 
@@ -199,4 +185,5 @@ class DocumentsAPI(ResourceAPI):
             doi=doc_data.get("doi"),
             inserted_at=doc_data.get("inserted_at"),
             updated_at=doc_data.get("updated_at"),
+            file_path=None,
         )

--- a/extralit/src/extralit/_models/_documents.py
+++ b/extralit/src/extralit/_models/_documents.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import os
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional
 from urllib.parse import unquote, urlparse
 from uuid import UUID
 
@@ -49,7 +49,7 @@ class DocumentModel(ResourceModel):
         file_path_or_url: str,
         *,
         reference: str,
-        workspace_id: Union[UUID, str],
+        workspace_id: UUID,
         id: Optional[UUID] = None,
         **kwargs: Any,
     ) -> "DocumentModel":
@@ -60,7 +60,7 @@ class DocumentModel(ResourceModel):
 
         elif urlparse(file_path_or_url).scheme:
             url = file_path_or_url
-            file_path_or_url = None
+            file_path_or_url = None  # type: ignore[assignment]
             parsed_url = urlparse(url)
             path = parsed_url.path
             file_name = unquote(path).split("/")[-1]

--- a/extralit/src/extralit/documents/_resource.py
+++ b/extralit/src/extralit/documents/_resource.py
@@ -51,10 +51,10 @@ class Document(Resource):
 
     def __init__(
         self,
-        workspace_id: Optional[UUID] = None,
+        workspace_id: UUID,
+        reference: str,
         file_name: Optional[str] = None,
         file_path: Optional[Union[str, Path]] = None,
-        reference: Optional[str] = None,
         url: Optional[str] = None,
         pmid: Optional[str] = None,
         doi: Optional[str] = None,
@@ -64,10 +64,10 @@ class Document(Resource):
         """Initializes a Document object.
 
         Parameters:
-            workspace_id (UUID): The workspace ID to which this document belongs.
+            workspace_id (UUID): The workspace ID to which this document belongs (required).
+            reference (str): A reference identifier for the document (required).
             file_name (str): The name of the document file.
             file_path (Union[str, Path]): Local path to the document file.
-            reference (str): A reference identifier for the document.
             url (str): The URL of the document.
             pmid (str): The PubMed ID of the document.
             doi (str): The DOI of the document.
@@ -100,7 +100,7 @@ class Document(Resource):
         file_path_or_url: Union[str, Path],
         *,
         reference: str,
-        workspace_id: Optional[UUID] = None,
+        workspace_id: UUID,
         pmid: Optional[str] = None,
         doi: Optional[str] = None,
         client: Optional["Extralit"] = None,
@@ -111,7 +111,6 @@ class Document(Resource):
             file_path_or_url: Local file path or URL to the document.
             reference: A reference identifier for the document.
             workspace_id: The workspace ID to which this document belongs.
-            id: The document ID. If provided, the document will be created with this ID.
             pmid: The PubMed ID of the document.
             doi: The DOI of the document.
             client: The client used to interact with Extralit.
@@ -120,8 +119,14 @@ class Document(Resource):
             Document: The created document object.
 
         Raises:
-            ValueError: If the file path does not exist or URL is invalid.
+            ValueError: If the file path does not exist or URL is invalid, or if required parameters are missing.
         """
+        if not workspace_id:
+            raise ValueError("workspace_id is required")
+
+        if not reference:
+            raise ValueError("reference is required")
+
         if isinstance(file_path_or_url, Path):
             file_path_or_url = str(file_path_or_url)
 
@@ -147,60 +152,6 @@ class Document(Resource):
             url=url,
             pmid=pmid,
             doi=doi,
-            client=client,
-        )
-
-    @classmethod
-    def from_pmid(
-        cls,
-        pmid: str,
-        *,
-        reference: Optional[str] = None,
-        workspace_id: Optional[UUID] = None,
-        client: Optional["Extralit"] = None,
-    ) -> "Document":
-        """Create a Document from a PubMed ID.
-
-        Args:
-            pmid: The PubMed ID.
-            reference: A reference identifier for the document.
-            workspace_id: The workspace ID to which this document belongs.
-            client: The client used to interact with Extralit.
-
-        Returns:
-            Document: The created document object.
-        """
-        return cls(
-            workspace_id=workspace_id,
-            pmid=pmid,
-            reference=reference or f"PMID:{pmid}",
-            client=client,
-        )
-
-    @classmethod
-    def from_doi(
-        cls,
-        doi: str,
-        *,
-        reference: Optional[str] = None,
-        workspace_id: Optional[UUID] = None,
-        client: Optional["Extralit"] = None,
-    ) -> "Document":
-        """Create a Document from a DOI.
-
-        Args:
-            doi: The DOI.
-            reference: A reference identifier for the document.
-            workspace_id: The workspace ID to which this document belongs.
-            client: The client used to interact with Extralit.
-
-        Returns:
-            Document: The created document object.
-        """
-        return cls(
-            workspace_id=workspace_id,
-            doi=doi,
-            reference=reference or f"DOI:{doi}",
             client=client,
         )
 
@@ -232,32 +183,50 @@ class Document(Resource):
     @classmethod
     def get(
         cls,
+        workspace_id: UUID,
+        reference: Optional[str] = None,
         id: Optional[UUID] = None,
         pmid: Optional[str] = None,
+        doi: Optional[str] = None,
         client: Optional["Extralit"] = None,
     ) -> "Document":
-        """Get a document by ID or PMID.
+        """Get a document by ID, PMID, DOI, reference, or workspace_id.
 
         Args:
+            workspace_id: The workspace ID (required).
             id: The document ID.
             pmid: The PubMed ID.
+            doi: The DOI.
+            reference: The document reference.
             client: The client used to interact with Extralit.
 
         Returns:
             Document: The document object.
 
         Raises:
-            ValueError: If neither id nor pmid is provided.
+            ValueError: If workspace_id is not provided or if none of id, pmid, doi, or reference is provided.
         """
+        if not workspace_id:
+            raise ValueError("workspace_id is required")
+
         client = client or Extralit._get_default()
 
+        # Build parameters object
+        params = {"workspace_id": str(workspace_id)}
         if id:
-            model = client.api.documents.get(id)
-        elif pmid:
-            model = client.api.documents.get_by_pmid(pmid)
-        else:
-            raise ValueError("Either id or pmid must be provided")
+            params["id"] = str(id)
+        if pmid:
+            params["pmid"] = pmid
+        if doi:
+            params["doi"] = doi
+        if reference:
+            params["reference"] = reference
 
+        # Ensure at least one identifier is provided in addition to workspace_id
+        if len(params) <= 1:  # Only workspace_id is provided
+            raise ValueError("At least one of id, pmid, doi, or reference must be provided in addition to workspace_id")
+
+        model: DocumentModel = client.api.documents.get(params)
         return cls.from_model(model, client)
 
     ############################
@@ -340,4 +309,4 @@ class Document(Resource):
         self._log_message(f"Document deleted: {self}")
 
     def _with_client(self, client: "Extralit") -> "Self":
-        return Document.from_model(self._model, client)
+        return Document.from_model(self._model, client)  # type: ignore[return-value]

--- a/extralit/tests/unit/api/test_workspace_documents_api.py
+++ b/extralit/tests/unit/api/test_workspace_documents_api.py
@@ -166,14 +166,14 @@ class TestDocumentResourceCRUD:
             reference="Retrieved2023",
             file_name="retrieved.pdf",
         )
-        documents_api.get_document.return_value = retrieved_model
+        documents_api.get.return_value = retrieved_model
 
         # Call get with required workspace_id
         with patch("extralit.documents._resource.Extralit._get_default", return_value=client):
             doc = Document.get(workspace_id=sample_workspace_id, id=sample_document_id)
 
         # Verify API was called with the new unified method
-        documents_api.get_document.assert_called_once_with(
+        documents_api.get.assert_called_once_with(
             {"workspace_id": str(sample_workspace_id), "id": str(sample_document_id)}
         )
 
@@ -229,13 +229,29 @@ class TestDocumentResourceCRUD:
         """Test Document factory methods."""
         client, documents_api = mock_client
 
+        # Mock the API responses for the get method
+        pmid_model = DocumentModel(
+            id=uuid4(),
+            workspace_id=sample_workspace_id,
+            reference="PMID:12345678",
+            pmid="12345678",
+        )
+        doi_model = DocumentModel(
+            id=uuid4(),
+            workspace_id=sample_workspace_id,
+            reference="DOI:10.1234/example",
+            doi="10.1234/example",
+        )
+
         with patch("extralit.documents._resource.Extralit._get_default", return_value=client):
             # Test the new unified get method with pmid
+            documents_api.get.return_value = pmid_model
             doc_pmid = Document.get(workspace_id=sample_workspace_id, pmid="12345678")
             assert doc_pmid.pmid == "12345678"
             assert doc_pmid.workspace_id == sample_workspace_id
 
             # Test the new unified get method with doi
+            documents_api.get.return_value = doi_model
             doc_doi = Document.get(workspace_id=sample_workspace_id, doi="10.1234/example")
             assert doc_doi.doi == "10.1234/example"
             assert doc_doi.workspace_id == sample_workspace_id

--- a/extralit/tests/unit/api/test_workspace_documents_api.py
+++ b/extralit/tests/unit/api/test_workspace_documents_api.py
@@ -187,7 +187,7 @@ class TestDocumentResourceCRUD:
         client, documents_api = mock_client
 
         # Create a document with existing data
-        doc = Document(id=sample_document_id, workspace_id=sample_workspace_id, reference="Original2023", client=client)
+        doc = Document(workspace_id=sample_workspace_id, reference="Original2023", id=sample_document_id, client=client)
 
         # Update some fields
         doc.reference = "Updated2023"
@@ -217,7 +217,7 @@ class TestDocumentResourceCRUD:
         client, documents_api = mock_client
 
         # Create a document
-        doc = Document(id=sample_document_id, workspace_id=sample_workspace_id, reference="ToDelete2023", client=client)
+        doc = Document(workspace_id=sample_workspace_id, reference="ToDelete2023", id=sample_document_id, client=client)
 
         # Call delete
         doc.delete()
@@ -230,13 +230,13 @@ class TestDocumentResourceCRUD:
         client, documents_api = mock_client
 
         with patch("extralit.documents._resource.Extralit._get_default", return_value=client):
-            # Test from_pmid - now requires workspace_id as required parameter
-            doc_pmid = Document.from_pmid(pmid="12345678", workspace_id=sample_workspace_id)
+            # Test the new unified get method with pmid
+            doc_pmid = Document.get(workspace_id=sample_workspace_id, pmid="12345678")
             assert doc_pmid.pmid == "12345678"
             assert doc_pmid.workspace_id == sample_workspace_id
 
-            # Test from_doi - now requires workspace_id as required parameter
-            doc_doi = Document.from_doi(doi="10.1234/example", workspace_id=sample_workspace_id)
+            # Test the new unified get method with doi
+            doc_doi = Document.get(workspace_id=sample_workspace_id, doi="10.1234/example")
             assert doc_doi.doi == "10.1234/example"
             assert doc_doi.workspace_id == sample_workspace_id
 

--- a/extralit/tests/unit/api/test_workspace_documents_api.py
+++ b/extralit/tests/unit/api/test_workspace_documents_api.py
@@ -157,19 +157,25 @@ class TestDocumentResourceCRUD:
     def test_document_get(self, mock_client, sample_document_id):
         """Test Document.get() class method."""
         client, documents_api = mock_client
+        sample_workspace_id = uuid4()
 
-        # Mock the API response
+        # Mock the API response - now returns a list
         retrieved_model = DocumentModel(
-            id=sample_document_id, workspace_id=uuid4(), reference="Retrieved2023", file_name="retrieved.pdf"
+            id=sample_document_id,
+            workspace_id=sample_workspace_id,
+            reference="Retrieved2023",
+            file_name="retrieved.pdf",
         )
-        documents_api.get.return_value = retrieved_model
+        documents_api.get_document.return_value = retrieved_model
 
-        # Call get
+        # Call get with required workspace_id
         with patch("extralit.documents._resource.Extralit._get_default", return_value=client):
-            doc = Document.get(id=sample_document_id)
+            doc = Document.get(workspace_id=sample_workspace_id, id=sample_document_id)
 
-        # Verify API was called
-        documents_api.get.assert_called_once_with(sample_document_id)
+        # Verify API was called with the new unified method
+        documents_api.get_document.assert_called_once_with(
+            {"workspace_id": str(sample_workspace_id), "id": str(sample_document_id)}
+        )
 
         # Verify result
         assert doc.id == sample_document_id
@@ -224,12 +230,12 @@ class TestDocumentResourceCRUD:
         client, documents_api = mock_client
 
         with patch("extralit.documents._resource.Extralit._get_default", return_value=client):
-            # Test from_pmid
+            # Test from_pmid - now requires workspace_id as required parameter
             doc_pmid = Document.from_pmid(pmid="12345678", workspace_id=sample_workspace_id)
             assert doc_pmid.pmid == "12345678"
             assert doc_pmid.workspace_id == sample_workspace_id
 
-            # Test from_doi
+            # Test from_doi - now requires workspace_id as required parameter
             doc_doi = Document.from_doi(doi="10.1234/example", workspace_id=sample_workspace_id)
             assert doc_doi.doi == "10.1234/example"
             assert doc_doi.workspace_id == sample_workspace_id


### PR DESCRIPTION
This pull request introduces significant improvements to the document retrieval system across both the frontend and backend, unifying and simplifying how documents are fetched by various identifiers (ID, PMID, DOI, reference) and workspace. It removes legacy endpoints and methods, centralizes document fetching logic, and updates the data models and API contracts accordingly. The changes also include type and signature improvements for better type safety and maintainability.

**Backend API and Logic Unification:**

* Replaced separate `/documents/by-id/{id}` and `/documents/by-pmid/{pmid}` endpoints with a single `/documents` endpoint that accepts `workspace_id` and one or more identifiers (`id`, `pmid`, `doi`, `reference`), returning a list of matching documents and providing better error handling for missing or ambiguous queries.
* Updated backend document fetching logic to use the new unified endpoint, including improved input validation and error messages.

**Frontend Document Fetching Refactor:**

* Refactored the frontend to use a single `fetchDocument` method that queries documents by any identifier and workspace, replacing the previous `fetchDocumentByID` and `fetchDocumentByPubmedID` methods. The view model and use case now expect and handle the new API response format. [[1]](diffhunk://#diff-d027c14067e21f3eb86f0bc31039e8bbc7eb036242ecf533941ded61e69cfff9L22-R69) [[2]](diffhunk://#diff-d027c14067e21f3eb86f0bc31039e8bbc7eb036242ecf533941ded61e69cfff9L110-L111) [[3]](diffhunk://#diff-ebe20a0cd31177a0ae9fe68208d60fe1407aca2e9addccae0335eaca923f2482L11-R30) [[4]](diffhunk://#diff-d02a9bc69e94f11f0803126cdc452b95adf8735b842117a6cb7bf978a02afafeR6-R28)

**Repository and Domain Model Updates:**

* Changed the frontend repository’s `getDocumentById` and `getDocumentByPubmedID` to a single `getDocuments` method that matches the new backend API, returning an array of documents. Updated the domain model to include `doi` as a possible identifier. [[1]](diffhunk://#diff-d02a9bc69e94f11f0803126cdc452b95adf8735b842117a6cb7bf978a02afafeR6-R28) [[2]](diffhunk://#diff-0a3871976ec3d7bd61087b00768f3fae783e7aeabc87cf34384c51cf8e922996R30)

**Type and Signature Improvements:**

* Added and improved type annotations throughout the codebase, including Vue components (`lang="ts"`), API handler signatures, and Minio/file handling code to improve code safety and clarity. [[1]](diffhunk://#diff-d5928b2735baae1a2a13afcb5ca753c478f7290fc079a5899d33cecffb067e8aL22-R22) [[2]](diffhunk://#diff-d5928b2735baae1a2a13afcb5ca753c478f7290fc079a5899d33cecffb067e8aL47-R48) [[3]](diffhunk://#diff-8082bfa052583032a51690a173dde2e5de97ee7691423329196aefe68e82924bL18-R20) [[4]](diffhunk://#diff-15da807f093c7a943d28757b744f9c15a6c3e6a3f01bde8035bb6e057e5a7c24L86-R88) [[5]](diffhunk://#diff-15da807f093c7a943d28757b744f9c15a6c3e6a3f01bde8035bb6e057e5a7c24L129-R130) [[6]](diffhunk://#diff-15da807f093c7a943d28757b744f9c15a6c3e6a3f01bde8035bb6e057e5a7c24L156-R157) [[7]](diffhunk://#diff-15da807f093c7a943d28757b744f9c15a6c3e6a3f01bde8035bb6e057e5a7c24L180-R187) [[8]](diffhunk://#diff-8d3dc711f8e7d46c114c3460e90cf5803bbe65c47e095f04fa1b78db9247c665L47-R50) [[9]](diffhunk://#diff-8d3dc711f8e7d46c114c3460e90cf5803bbe65c47e095f04fa1b78db9247c665L61-R61) [[10]](diffhunk://#diff-8d3dc711f8e7d46c114c3460e90cf5803bbe65c47e095f04fa1b78db9247c665L79-R82) [[11]](diffhunk://#diff-8d3dc711f8e7d46c114c3460e90cf5803bbe65c47e095f04fa1b78db9247c665L117-R124)

**Minor Fixes and Cleanups:**

* Fixed small issues and improved error messages, default values, and parameter handling in various locations for robustness and maintainability. [[1]](diffhunk://#diff-15da807f093c7a943d28757b744f9c15a6c3e6a3f01bde8035bb6e057e5a7c24R237) [[2]](diffhunk://#diff-8082bfa052583032a51690a173dde2e5de97ee7691423329196aefe68e82924bL74-R74) [[3]](diffhunk://#diff-1567610b8478c23b78819e48b742630c519b3ff3deb4d8deb9193447786520a4L75-R80)

These changes together make document retrieval more robust, flexible, and maintainable across the application.