### PR TITLE
fix: resolve PDF upload validation when bibliography file is uploaded…

### DIFF
--- a/extralit-frontend/components/features/import/file-upload/usePdfUploadLogic.ts
+++ b/extralit-frontend/components/features/import/file-upload/usePdfUploadLogic.ts
@@ -162,7 +162,7 @@ export const usePdfUploadLogic = (
   const emitUpdate = () => {
     if (emit) {
       emit("update", {
-        isValid: uploaded.value && !hasError.value && data.value.matchedFiles.length > 0,
+        isValid: uploaded.value && !hasError.value && data.value.totalFiles > 0,
         matchedFiles: data.value.matchedFiles,
         unmatchedFiles: data.value.unmatchedFiles,
         totalFiles: data.value.totalFiles,
@@ -260,6 +260,22 @@ export const usePdfUploadLogic = (
       }
     },
     { deep: true, immediate: true }
+  );
+
+  // Watch for bibliography entries being added later (when bib file is uploaded after PDFs)
+  watch(
+    () => props.bibliographyEntries,
+    (newBibEntries, oldBibEntries) => {
+      const hadNoBibBefore = !oldBibEntries || !oldBibEntries.data || oldBibEntries.data.length === 0;
+      const hasValidBibNow = newBibEntries && newBibEntries.data && newBibEntries.data.length > 0;
+
+      if (hasValidBibNow && hadNoBibBefore && data.value.totalFiles > 0) {
+        const allFiles = [...data.value.matchedFiles.map(mf => mf.file), ...data.value.unmatchedFiles];
+        performFileMatching(allFiles);
+        emitUpdate();
+      }
+    },
+    { deep: true }
   );
 
   // Initialize on mount


### PR DESCRIPTION
# Fix: Resolve PDF upload validation when bibliography file is uploaded after PDFs

## Summary
- Changed validation logic from `matchedFiles.length > 0` to `totalFiles > 0`
- Added watcher to re-trigger file matching when bibliography data becomes available
- Implemented guard conditions to prevent infinite re-render loops
- Fixed MinIO upload flow to work regardless of PDF/bibliography upload order

## Description
After changing the import flow to make PDFs mandatory and bibliography files optional (allowing PDFs to be uploaded first), files were not being uploaded to MinIO storage when PDFs were uploaded before the bibliography file. The upload only worked when the bibliography file was uploaded first, then PDFs second.

### Root Cause
The validation logic in `usePdfUploadLogic.ts` was checking for `matchedFiles.length > 0` to determine if the upload was valid. When PDFs are uploaded before bibliography data exists, all files are categorized as "unmatched", resulting in an empty `matchedFiles` array. This caused `isValid` to be `false`, preventing the workflow from proceeding to the MinIO upload step.

### Solution
1. **Updated validation logic**: Changed from requiring matched files to only requiring total files > 0
2. **Added auto-matching**: Implemented a watcher that automatically re-triggers file matching when bibliography data becomes available after PDFs are uploaded
3. **Prevented infinite loops**: Added guard conditions to ensure the watcher only triggers on the transition from "no bibliography" to "has bibliography"

## Related Tickets & Documents
Closes #172

## What type of PR is this?
- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Steps to QA

### Test Case 1: Upload PDFs first, then bibliography
1. Navigate to the import workflow
2. Click on PDF upload section and upload one or more PDF files
3. Verify PDFs are displayed in the upload area
4. Click "Next" - should be enabled
5. Now upload a .bib or .csv bibliography file
6. Verify that auto-matching occurs (matched files counter updates)
7. Proceed through the workflow
8. **Expected**: Files should be successfully uploaded to MinIO bucket
9. Verify in MinIO bucket that all files are present

### Test Case 2: Upload bibliography first, then PDFs (original flow)
1. Navigate to the import workflow
2. Upload a .bib or .csv bibliography file first
3. Verify bibliography data is displayed
4. Upload PDF files
5. Verify auto-matching occurs immediately
6. Proceed through the workflow
7. **Expected**: Files should be successfully uploaded to MinIO bucket
8. Verify in MinIO bucket that all files are present

### Test Case 3: Upload only PDFs (no bibliography)
1. Navigate to the import workflow
2. Upload only PDF files (do not upload bibliography)
3. Click "Next" - should be enabled
4. Proceed through the workflow
5. **Expected**: PDFs should upload to MinIO, all files marked as "unmatched"
6. User should be able to edit metadata in the next step

## Files Modified
- `extralit-frontend/components/features/import/file-upload/usePdfUploadLogic.ts`
  - Updated `emitUpdate()` validation logic
  - Added watcher for bibliography entries with guard conditions

## Checklist
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
- [x] My code follows the code style of this project
- [x] I have tested the changes locally
- [x] All new and existing tests pass
- [x] I have checked for console errors/warnings


### Before (Bug):
- PDFs uploaded first → Files not in MinIO ❌

### After (Fixed):
- PDFs uploaded first → Files successfully uploaded to MinIO ✅
- Auto-matching works when bibliography uploaded after PDFs ✅
- No UI freezing when navigating back/forth ✅

## Additional Notes
This fix is part of the larger effort to make the bibliography file optional in the import workflow. Future PRs will handle additional scenarios where only PDFs are uploaded without any bibliography metadata.