### PR TITLE
[fix] Prevent empty UI when deleting a table

### DIFF
--- a/extralit-frontend/components/base/base-render-table/RenderTable.vue
+++ b/extralit-frontend/components/base/base-render-table/RenderTable.vue
@@ -581,7 +581,9 @@ export default {
     },
     clearTable() {
       if (this.tabulator?.getDataCount() == 0) {
-        this.tableJSON = undefined;
+        this.$emit("change-text", "");
+        this.exitEditionMode();
+        this.dropdownEditTableVisible = false;
         return;
       }
       this.tabulator?.clearData()
@@ -590,6 +592,7 @@ export default {
           this.tabulator?.deleteColumn(column);
         }
       });
+      this.updateTableJsonData();
     },
     addEmptyReferenceRows() {
       const combinations = this.generateCombinations(this.referenceValues);


### PR DESCRIPTION
## Description

This PR fixes the UI/UX issue where deleting a table via “Edit table → Clear data” followed by “Edit table → Delete” leaves an empty, non-interactive box instead of reverting back to a blank text area.

The issue occurred because the table component remained mounted after deletion without notifying the parent renderer to switch back to text mode.

## Related Tickets & Documents

Closes #19 


## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Steps to QA

1. Creating a table with data
2. Clearing the table data using "Edit table > Clear data"
3. Deleting the table using "Edit table > Delete"
4. Verifying that no empty box remains and the area resets to a blank text area


## Added/updated tests?

- [ ] Yes
- [x] No, and this is why:  the change fixes internal UI behavior and does not affect public APIs or documented workflows.
- [ ] I need help with writing tests

## Added/updated documentations?

- [ ] Yes
- [x] No, and this is why: the change fixes internal UI behavior and does not affect public APIs or documented workflows.
- [ ] I need help with writing docs

## Checklist
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)

