### PR TITLE
Added toast notification for duplicate 

### DIFF
--- a/extralit-frontend/components/features/annotation/settings/useSettingsQuestionsViewModel.ts
+++ b/extralit-frontend/components/features/annotation/settings/useSettingsQuestionsViewModel.ts
@@ -2,9 +2,11 @@ import { ref } from "@nuxtjs/composition-api";
 import { useResolve } from "ts-injecty";
 import { Question } from "~/v1/domain/entities/question/Question";
 import { UpdateQuestionSettingUseCase } from "~/v1/domain/usecases/dataset-setting/update-question-setting-use-case";
+import { useNotifications } from "~/v1/infrastructure/services/useNotifications";
 
 export const useSettingsQuestionsViewModel = () => {
   const updateQuestionSettingsUseCase = useResolve(UpdateQuestionSettingUseCase);
+  const notification = useNotifications();
   const newLabelText = ref({});
 
   const restore = (question: Question) => {
@@ -29,7 +31,10 @@ export const useSettingsQuestionsViewModel = () => {
     );
 
     if (existingOption) {
-      // TODO: Show error message that option already exists
+      notification.notify({
+        message: "Label already exists. Please choose a different one.",
+        type: "warning",
+      });
       return;
     }
 


### PR DESCRIPTION
PR Title format:\[Fix\] Resolve error handling for duplicate option label

## Description

This PR fixes the duplicate option UX by showing a toast error when a user adds an option label that already exists.

## Related Tickets & Documents

Closes Extralit/extralit#182

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Steps to QA

1.Go to Dataset Settings → Questions.  <br>2.Add a new option label that already exists.  <br>3.Confirm a toast appears saying “Option already exists” and the option is not added

https://github.com/user-attachments/assets/d11a038e-961c-4580-98d9-5283dcbfe211

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: UI/UX change
- [ ] I need help with writing tests

## Added/updated documentations?

- [ ] Yes
- [X] No, and this is why: UI/UX change
- [ ] I need help with writing docs

## Checklist

- [ ] I have added relevant notes to the CHANGELOG.md file (See [https://keepachangelog.com/](<https://keepachangelog.com/>))