### PR TITLE
refactor: use native str.removesuffix instead of custom helper

### DIFF
--- a/extralit-server/src/extralit_server/_app.py
+++ b/extralit-server/src/extralit_server/_app.py
@@ -264,7 +264,7 @@ def configure_app_statics(app: FastAPI):
         BASE_URL_VAR_NAME = "@@baseUrl@@"
         temp_dir = tempfile.mkdtemp()
         new_folder = shutil.copytree(path_from, temp_dir + "/statics")
-        base_url = helpers.remove_suffix(settings.base_url or "", suffix="/")
+        base_url = (settings.base_url or "").removesuffix("/")
         for extension in ["*.js", "*.html"]:
             for file in glob.glob(
                 f"{new_folder}/**/{extension}",

--- a/extralit-server/src/extralit_server/helpers.py
+++ b/extralit-server/src/extralit_server/helpers.py
@@ -544,12 +544,7 @@ async def create_s3_client() -> "S3Client":
     return s3_client
 
 
-def remove_suffix(text: str, suffix: str):
-    # TODO Move where is used
-    """Give a text, removes suffix substring from it"""
-    if text.endswith(suffix):
-        return text[: -len(suffix)]
-    return text
+
 
 
 def replace_string_in_file(filename: str, string: str, replace_by: str, encoding: str = "utf-8"):


### PR DESCRIPTION
## Description

This PR removes the redundant `remove_suffix` helper function from [helpers.py](cci:7://file:///c:/Users/karns/Documents/GitHub/extralit/extralit-server/src/extralit_server/helpers.py:0:0-0:0) and replaces its single usage in [_app.py](cci:7://file:///c:/Users/karns/Documents/GitHub/extralit/extralit-server/src/extralit_server/_app.py:0:0-0:0) with Python's built-in `str.removesuffix()` method (available since Python 3.9).

Since the project requires Python ≥3.10, this is safe to use and reduces code maintenance burden.

## Related Tickets & Documents

N/A - Code cleanup/modernization

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Steps to QA

1. Start the server with a custom `base_url` setting ending with `/`
2. Verify static files are served correctly (the trailing slash is stripped as expected)
3. Run existing tests to ensure no regressions

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: The native Python method `str.removesuffix()` is part of the standard library and is well-tested. The refactor is a 1:1 behavioral replacement verified through manual testing.
- [ ] I need help with writing tests

## Added/updated documentations?

- [ ] Yes
- [x] No, and this is why: This is an internal refactor with no user-facing changes.
- [ ] I need help with writing docs

## Checklist
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)