### PR TITLE
[fix]Fix document status bug

### DIFF
--- a/extralit-frontend/components/features/import/ImportFlow.vue
+++ b/extralit-frontend/components/features/import/ImportFlow.vue
@@ -274,6 +274,7 @@ export default {
         dataframeData: data.dataframeData || null,
         rawContent: data.rawContent || "",
       };
+      this.uploadData.documentActions = {};
       this.clearError();
     },
 
@@ -283,6 +284,7 @@ export default {
         unmatchedFiles: data.unmatchedFiles || [],
         totalFiles: data.totalFiles || 0,
       };
+      this.uploadData.documentActions = {};
       this.clearError();
     },
 

--- a/extralit-frontend/components/features/import/ImportFlow.vue
+++ b/extralit-frontend/components/features/import/ImportFlow.vue
@@ -36,6 +36,7 @@
         :pdf-data="pdfData"
         :workspace="workspace"
         :loading="isAnalyzing"
+        :initial-document-actions="uploadData.documentActions"
         @update="handleAnalysisUpdate"
         @analysis-complete="handleAnalysisComplete"
       />

--- a/extralit-frontend/components/features/import/analysis/ImportAnalysisTable.spec.ts
+++ b/extralit-frontend/components/features/import/analysis/ImportAnalysisTable.spec.ts
@@ -1,0 +1,49 @@
+import ImportAnalysisTable from "./ImportAnalysisTable.vue";
+import ImportFlow from "../ImportFlow.vue";
+
+describe("ImportAnalysisTable document actions", () => {
+  it("restores persisted actions when the review step is remounted", () => {
+    const component = ImportAnalysisTable as any;
+    const state = component.data.call({ initialDocumentActions: { keep: "ignore" } });
+
+    expect(state.localDocumentActions).toEqual({ keep: "ignore" });
+    expect(state.editableTableData).toEqual([]);
+  });
+
+  it("keeps only persisted actions that belong to the latest analysis", () => {
+    const component = ImportAnalysisTable as any;
+    const context = {
+      initialDocumentActions: { keep: "ignore", stale: "update" },
+      localDocumentActions: {},
+      $emit: vi.fn(),
+      emitUpdate: vi.fn(),
+    };
+
+    component.watch.analysisResult.handler.call(context, {
+      documents: { keep: {} },
+    });
+
+    expect(context.localDocumentActions).toEqual({ keep: "ignore" });
+    expect(context.$emit).toHaveBeenCalledWith("analysis-complete", { documents: { keep: {} } });
+    expect(context.emitUpdate).toHaveBeenCalledOnce();
+  });
+});
+
+describe("ImportFlow input changes", () => {
+  it("clears persisted actions when the bibliography or PDFs change", () => {
+    const component = ImportFlow as any;
+    const context = {
+      bibData: {},
+      pdfData: {},
+      uploadData: { documentActions: { previous: "ignore" } },
+      clearError: vi.fn(),
+    };
+
+    component.methods.handleBibUpdate.call(context, { fileName: "new.bib" });
+    expect(context.uploadData.documentActions).toEqual({});
+
+    context.uploadData.documentActions = { previous: "ignore" };
+    component.methods.handlePdfUpdate.call(context, { totalFiles: 1 });
+    expect(context.uploadData.documentActions).toEqual({});
+  });
+});

--- a/extralit-frontend/components/features/import/analysis/ImportAnalysisTable.vue
+++ b/extralit-frontend/components/features/import/analysis/ImportAnalysisTable.vue
@@ -107,13 +107,17 @@ export default {
       type: Boolean,
       default: false,
     },
+    initialDocumentActions: {
+      type: Object as () => Record<string, ImportStatus>,
+      default: () => ({}),
+    },
   },
 
   emits: ["update", "analysis-complete"],
 
   data() {
     return {
-      localDocumentActions: {} as Record<string, ImportStatus>,
+      localDocumentActions: { ...this.initialDocumentActions } as Record<string, ImportStatus>,
       editableTableData: [] as any[],
     };
   },
@@ -439,8 +443,10 @@ export default {
     analysisResult: {
       handler(newData: ImportAnalysisResponse) {
         if (newData) {
-          // Reset local document actions when new analysis data arrives
-          this.localDocumentActions = {};
+          // Preserve status overrides when this step is remounted.
+          if (!this.initialDocumentActions || Object.keys(this.initialDocumentActions).length === 0) {
+            this.localDocumentActions = {};
+          }
           // Emit the analysis complete event
           this.$emit("analysis-complete", newData);
           // Emit initial update

--- a/extralit-frontend/components/features/import/analysis/ImportAnalysisTable.vue
+++ b/extralit-frontend/components/features/import/analysis/ImportAnalysisTable.vue
@@ -443,10 +443,18 @@ export default {
     analysisResult: {
       handler(newData: ImportAnalysisResponse) {
         if (newData) {
-          // Preserve status overrides when this step is remounted.
-          if (!this.initialDocumentActions || Object.keys(this.initialDocumentActions).length === 0) {
-            this.localDocumentActions = {};
+          // Filter persisted actions to only keys present in the new analysis,
+          // discarding stale entries from a previous Bib/PDF set
+          const validKeys = new Set(Object.keys(newData.documents ?? {}));
+          const filtered: Record<string, ImportStatus> = {};
+          if (this.initialDocumentActions) {
+            for (const [key, status] of Object.entries(this.initialDocumentActions)) {
+              if (validKeys.has(key)) {
+                filtered[key] = status as ImportStatus;
+              }
+            }
           }
+          this.localDocumentActions = filtered;
           // Emit the analysis complete event
           this.$emit("analysis-complete", newData);
           // Emit initial update


### PR DESCRIPTION
## Description

\[Fix document status selections being lost when users click "Previous" and return to the Import Analysis table<br>\]

## Related Tickets & Documents

Closes [#184](<https://github.com/Extralit/extralit/issues/184>)

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Steps to QA

1.Navigate to a workspace and open the Import Flow modal<br>2.Upload test PDFs and a valid BibTeX bibliography file<br>3.Click "Next" to proceed to Step 1 (Import Analysis Table)<br>4.Click on a status badge to toggle it (Add → Ignore)<br>5.Toggle several document statuses to different values<br>6.Click "Previous" button to return to Step 0 (file upload)<br>7.Click "Next" to return to Step 1 (Analysis Table)<br>8.Verify all previously toggled statuses are preserved

https://github.com/user-attachments/assets/f8da6a54-0a6a-49a2-ba8b-6964fc23f055

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why :bug fix
- [ ] I need help with writing tests

## Added/updated documentations?

- [ ] Yes
- [X] No, and this is why: bug fix
- [ ] I need help with writing docs

## Checklist

- [ ] I have added relevant notes to the CHANGELOG.md file (See [https://keepachangelog.com/](<https://keepachangelog.com/>))

The columnConfigs prop I added to RenderTable/BaseSimpleTable is a generic column override mechanism (similar to how most table libraries work). It doesn't store any document-specific state localDocumentActions still lives entirely in ImportAnalysisTable.vue.

The reason those general component changes are needed is that BaseSimpleTable.computedTableJSON only carries field names/types when building the schema, so custom formatters like statusFormatter and handleStatusClick defined in ImportAnalysisTable.tableColumns would be silently dropped without a way to pass them through to RenderTable.