### PR TITLE
[Docs] fix broken development setup link in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,6 @@ The contributor guide covers:
 
 ## Development setup
 
-Refer to our [development setup documentation](https://docs.extralit.ai/latest/getting_started/development_setup.md) for instructions on setting up your local environment.
+Refer to our [development setup documentation](https://docs.extralit.ai/latest/getting_started/development_setup/) for instructions on setting up your local environment.
 
 Thank you for contributing to Extralit! 🚀


### PR DESCRIPTION
## Description

While following the contributor guide, I noticed that the development setup documentation link in [CONTRIBUTING.md](https://github.com/Extralit/extralit/blob/develop/CONTRIBUTING.md) was pointing to a non-existent page and resulted in a `404`.

The current link:

https://docs.extralit.ai/latest/getting_started/development_setup.md

has been updated to the correct working documentation page:

https://docs.extralit.ai/latest/getting_started/development_setup

This ensures new contributors can properly access the development setup instructions and get started without confusion.

## Related Tickets & Documents

Closes #189 

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Steps to QA

1. Open **CONTRIBUTING.md**
2. Scroll to the Development setup section
3. Click the development setup documentation link
4. Confirm it opens the correct documentation page instead of a 404 error

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: This change only updates a documentation link and does not affect application logic or functionality.
- [ ] I need help with writing tests

## Added/updated documentations?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing docs

## Checklist
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)

