### PR TITLE
[Fix] Remove ARM-specific JVM options from Elasticsearch configuration

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -81,8 +81,7 @@ services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.17.0
     environment:
-      - ES_JAVA_OPTS=-Xms512m -Xmx512m -XX:UseSVE=0
-      - CLI_JAVA_OPTS=-XX:UseSVE=0
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
       - node.name=elasticsearch
       - cluster.name=es-extralit-local
       - discovery.type=single-node

--- a/extralit-server/CHANGELOG.md
+++ b/extralit-server/CHANGELOG.md
@@ -26,6 +26,7 @@ These are the section headers that we use:
 - Added `wait` parameter to the POST /workflows/start endpoint to waiting for the workflow to complete and return the final status.
 - Migrated minio_client to aioboto3 for async file handling
 - Added dynamic mimetypes support for document uploads based on file extension or UploadFile types.
+- Removed ARM-specific JVM options (`-XX:UseSVE=0`) from Elasticsearch configuration in docker-compose.yaml, fixing container startup failures on Windows and x86 systems.
 
 ### Changed
 - Deduplicating document is based on any matching of id, pmid, doi, url, file_name within the same `workspace` and `reference`.


### PR DESCRIPTION
PR Title:


[Fix] Remove ARM-specific JVM options from Elasticsearch configuration

## Description

This PR fixes the Elasticsearch container startup failure on Windows/x86 systems by removing ARM-specific JVM options that are not compatible with x86 architectures.

The `-XX:UseSVE=0` JVM flag (which disables ARM's Scalable Vector Extension) was causing the following error on Windows and x86 Linux systems:
Unrecognized VM option 'UseSVE=0'
Error: Could not create the Java Virtual Machine.

This makes it work on all system architectures.

## Related Tickets & Documents

Closes #187 

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Steps to QA

1. On a Windows or x86 Linux system, run `docker-compose down` to stop existing containers(if not already deployed)
2. Run `docker-compose up -d elasticsearch` to start Elasticsearch(can also run whole app but check for elasticsearch errors)
3. Check logs `docker logs extralit-elasticsearch-1`
4. Verify Elasticsearch starts successfully without JVM errors
5. also test on ARM-based systems (Apple Silicon, AWS Graviton) to ensure compatibility is maintained

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: docker doesnt require tests 
- [ ] I need help with writing tests

## Added/updated documentations?

- [ ] Yes
- [x] No, and this is why: bug fix in docker file(no docs needed)
- [ ] I need help with writing docs

## Checklist
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachange