### PR TITLE
fix: add word-wrap support for code snippets in docs - fixes #181

### DIFF
--- a/extralit/docs/stylesheets/extra.css
+++ b/extralit/docs/stylesheets/extra.css
@@ -151,3 +151,11 @@
     transform-origin: left top;
   }
 }
+
+/* Fix: Add word-wrap support for code snippets in documentation - GSoC 2026 */
+pre,
+code {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}


### PR DESCRIPTION
## Description
This PR fixes the word-wrap issue in documentation code snippets.

Code snippets were extending horizontally and requiring scrolling, 
making them hard to read especially on smaller screens.

## Changes
- Added `white-space: pre-wrap` 
- Added `word-wrap: break-word`
- Added `overflow-wrap: break-word`
to `extra.css` stylesheet.

## Related Tickets & Documents
Fixes #181

## GSoC 2026
This contribution is part of my GSoC 2026 application to Extralit 
under Open Science Labs.