### PR TITLE
feat: implement recursive chunking with chonkie and persist to db

### DIFF
--- a/extralit-server/CHANGELOG.md
+++ b/extralit-server/CHANGELOG.md
@@ -1277,6 +1277,7 @@ These are the section headers that we use:
 
 ### Added
 
+- Added recursive text chunking via Chonkie and persisted chunks to database metadata
 - Add the fields to retrieve when loading the data from argilla. `rg.load` takes too long because of the vector field, even when users don't need it. Closes [#2398](https://github.com/argilla-io/argilla/issues/2398)
 - Add new page and components for dataset settings. Closes [#2442](https://github.com/argilla-io/argilla/issues/2003)
 - Add ability to show image in records (for TokenClassification and TextClassification) if an URL is passed in metadata with the key \_image_url

--- a/extralit-server/CHANGELOG.md
+++ b/extralit-server/CHANGELOG.md
@@ -18,6 +18,13 @@ These are the section headers that we use:
 ### Added
 
 - Refactor document analysis and preprocessing job to support asynchronous s3 IO operations and large file processing.
+- Added text chunking pipeline using chonkie `RecursiveChunker` with a new RQ job (`process_text_extraction_result_job`) that extracts text from OCR JSON results, chunks it, and persists chunks to `documents.metadata_` in the database.
+- Added `ChunkMetadata` schema and `chunks` field to `TextExtractionMetadata` for storing text chunks alongside extracted text.
+- Added `chonkie>=1.0.2` as a dependency.
+
+### Removed
+
+- Removed `InMemoryChunkStore` (`chunk_store.py`) — chunks are now persisted to the database instead of a process-local dict.
 
 ### Fixed
 
@@ -1277,7 +1284,6 @@ These are the section headers that we use:
 
 ### Added
 
-- Added recursive text chunking via Chonkie and persisted chunks to database metadata
 - Add the fields to retrieve when loading the data from argilla. `rg.load` takes too long because of the vector field, even when users don't need it. Closes [#2398](https://github.com/argilla-io/argilla/issues/2398)
 - Add new page and components for dataset settings. Closes [#2442](https://github.com/argilla-io/argilla/issues/2003)
 - Add ability to show image in records (for TokenClassification and TextClassification) if an URL is passed in metadata with the key \_image_url

--- a/extralit-server/pyproject.toml
+++ b/extralit-server/pyproject.toml
@@ -72,6 +72,7 @@ dependencies = [
     "aioboto3>=13.1.1",
     "types-aiobotocore-s3==2.24.2",
     # For document processing
+    "chonkie>=1.0.2",
     "ocrmypdf>=16.11.0",
     "pdf2image>=1.17.0",
     "opencv-python-headless>=4.11.0.86",

--- a/extralit-server/src/extralit_server/api/schemas/v1/document/metadata.py
+++ b/extralit-server/src/extralit_server/api/schemas/v1/document/metadata.py
@@ -58,11 +58,21 @@ class PreprocessingMetadata(BaseModel):
     processed_s3_url: Optional[str] = Field(None, description="S3 URL of processed PDF")
 
 
+class ChunkMetadata(BaseModel):
+    """A single text chunk produced by the chunker."""
+
+    text: str = Field(..., description="Chunk text content")
+    start_index: int = Field(..., description="Character start offset in source text")
+    end_index: int = Field(..., description="Character end offset in source text")
+    token_count: int = Field(..., description="Number of tokens in the chunk")
+
+
 class TextExtractionMetadata(BaseModel):
     """Text extraction job results."""
 
     markdown: str = Field(None, description="Extracted text")
     extraction_method: str = Field(..., description="Method used for extraction")
+    chunks: Optional[list[ChunkMetadata]] = Field(None, description="Text chunks for embedding / retrieval")
 
 
 class DocumentProcessingMetadata(BaseModel):
@@ -109,6 +119,16 @@ class DocumentProcessingMetadata(BaseModel):
             processing_time=preprocess_result["processing_time"],
             ocr_applied=preprocess_result.get("ocr_applied", False),
             processed_s3_url=preprocess_result.get("processed_s3_url"),
+        )
+
+    def update_text_extraction_results(
+        self, text: str, chunks: list[dict], extraction_method: str = "external_ocr"
+    ) -> None:
+        """Update text extraction metadata including chunks."""
+        self.text_extraction_metadata = TextExtractionMetadata(
+            markdown=text,
+            extraction_method=extraction_method,
+            chunks=[ChunkMetadata(**c) for c in chunks],
         )
 
     def is_workflow_complete(self) -> bool:

--- a/extralit-server/src/extralit_server/contexts/document/chunker.py
+++ b/extralit-server/src/extralit_server/contexts/document/chunker.py
@@ -12,7 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Document text chunking using chonkie's RecursiveChunker.
+"""Context-aware semantic chunking using chonkie's RecursiveChunker.
+
+Uses ``RecursiveChunker.from_recipe("markdown")`` which applies a hierarchy
+of Markdown-aware splitting rules:
+
+1. Markdown headers (``#`` through ``######``), kept attached to subsequent
+   text via ``include_delim="next"``.
+2. Double newlines (``\\n\\n``) for paragraph boundaries.
+3. Single newlines, then sentence-ending punctuation (``.``, ``!``, ``?``).
+
+This produces semantically contiguous chunks aligned with document sections
+instead of fixed-size token windows.
 
 See https://docs.chonkie.ai/oss/chunkers/recursive-chunker
 """
@@ -20,21 +31,95 @@ See https://docs.chonkie.ai/oss/chunkers/recursive-chunker
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 from chonkie import RecursiveChunker
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_CHUNK_SIZE = 512
+DEFAULT_CHUNK_SIZE = 2048
+DEFAULT_TABLE_CHUNK_SIZE = 900
+
+_TABLE_HEADER_RE = re.compile(r"^\s*Table\s+\d+\b", re.IGNORECASE)
+_TABLE_TERM_RE = re.compile(r"\b(?:OR|CI|P|Genotypes|RR|RS|SS)\b")
+_TABLE_INTERVAL_RE = re.compile(r"\(D\d+\s*[-–]\s*D\d+\)|\(D\d+\)")
+
+
+def _is_table_header(text: str) -> bool:
+    """Return True if *text* starts with a table heading."""
+    return bool(_TABLE_HEADER_RE.match(text.strip()))
+
+
+def _looks_like_table_continuation(text: str) -> bool:
+    """Heuristically identify table-like continuation fragments.
+
+    Scientific PDFs often extract table cells as many short lines. This helper
+    flags those chunks so we can keep table header/body together.
+    """
+    stripped = text.strip()
+    if not stripped:
+        return False
+
+    lines = [line.strip() for line in stripped.splitlines() if line.strip()]
+    if len(lines) < 4:
+        return False
+
+    short_line_count = sum(1 for line in lines if len(line) <= 20)
+    numeric_like_count = sum(1 for line in lines if re.search(r"\d|%|±|×|<|>", line))
+    has_table_terms = _TABLE_TERM_RE.search(stripped) is not None
+    has_intervals = _TABLE_INTERVAL_RE.search(stripped) is not None
+
+    return (short_line_count / len(lines) >= 0.55) and (
+        (numeric_like_count / len(lines) >= 0.35) or has_table_terms or has_intervals
+    )
+
+
+def _merge_adjacent_table_chunks(chunks: list[dict[str, Any]], max_table_chunk_size: int) -> list[dict[str, Any]]:
+    """Merge table heading + continuation chunks to preserve table context."""
+    if not chunks:
+        return []
+
+    merged: list[dict[str, Any]] = []
+    i = 0
+
+    while i < len(chunks):
+        current = dict(chunks[i])
+
+        if _is_table_header(current.get("text", "")) and i + 1 < len(chunks):
+            while i + 1 < len(chunks):
+                next_chunk = chunks[i + 1]
+                next_text = next_chunk.get("text", "")
+                combined_token_count = current.get("token_count", 0) + next_chunk.get("token_count", 0)
+
+                if combined_token_count > max_table_chunk_size:
+                    break
+
+                if not _looks_like_table_continuation(next_text):
+                    break
+
+                current["text"] = f"{current.get('text', '')}{next_text}"
+                current["end_index"] = next_chunk.get("end_index", current.get("end_index"))
+                current["token_count"] = combined_token_count
+                i += 1
+
+        merged.append(current)
+        i += 1
+
+    return merged
 
 
 def chunk_text(
     text: str,
     *,
     chunk_size: int = DEFAULT_CHUNK_SIZE,
+    merge_table_chunks: bool = True,
+    max_table_chunk_size: int = DEFAULT_TABLE_CHUNK_SIZE,
 ) -> list[dict[str, Any]]:
-    """Chunk *text* using chonkie's ``RecursiveChunker``.
+    """Chunk *text* using chonkie's Markdown-aware ``RecursiveChunker``.
+
+    Splits on Markdown headers first, then paragraph breaks, then
+    sentences — producing semantically contiguous, section-aligned chunks.
 
     Returns a list of plain dicts (JSON-serialisable) with keys:
         - ``text``: the chunk content
@@ -45,7 +130,9 @@ def chunk_text(
     if not text or not text.strip():
         return []
 
-    chunker = RecursiveChunker(
+    chunker = RecursiveChunker.from_recipe(
+        "markdown",
+        lang="en",
         chunk_size=chunk_size,
     )
 
@@ -60,8 +147,11 @@ def chunk_text(
             "token_count": chunk.token_count,
         })
 
+    if merge_table_chunks:
+        result = _merge_adjacent_table_chunks(result, max_table_chunk_size=max_table_chunk_size)
+
     _LOGGER.debug(
-        "Chunked %d chars into %d chunks (size=%d)",
-        len(text), len(result), chunk_size,
+        "Chunked %d chars into %d chunks (size=%d, merge_table_chunks=%s)",
+        len(text), len(result), chunk_size, merge_table_chunks,
     )
     return result

--- a/extralit-server/src/extralit_server/contexts/document/chunker.py
+++ b/extralit-server/src/extralit_server/contexts/document/chunker.py
@@ -1,0 +1,67 @@
+# Copyright 2024-present, Extralit Labs, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Document text chunking using chonkie's RecursiveChunker.
+
+See https://docs.chonkie.ai/oss/chunkers/recursive-chunker
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from chonkie import RecursiveChunker
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_CHUNK_SIZE = 512
+
+
+def chunk_text(
+    text: str,
+    *,
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
+) -> list[dict[str, Any]]:
+    """Chunk *text* using chonkie's ``RecursiveChunker``.
+
+    Returns a list of plain dicts (JSON-serialisable) with keys:
+        - ``text``: the chunk content
+        - ``start_index``: character start offset in the original text
+        - ``end_index``: character end offset in the original text
+        - ``token_count``: number of tokens in the chunk
+    """
+    if not text or not text.strip():
+        return []
+
+    chunker = RecursiveChunker(
+        chunk_size=chunk_size,
+    )
+
+    chunks = chunker.chunk(text)
+
+    result: list[dict[str, Any]] = []
+    for chunk in chunks:
+        result.append({
+            "text": chunk.text,
+            "start_index": chunk.start_index,
+            "end_index": chunk.end_index,
+            "token_count": chunk.token_count,
+        })
+
+    _LOGGER.debug(
+        "Chunked %d chars into %d chunks (size=%d)",
+        len(text), len(result), chunk_size,
+    )
+    return result

--- a/extralit-server/src/extralit_server/jobs/document_jobs.py
+++ b/extralit-server/src/extralit_server/jobs/document_jobs.py
@@ -23,9 +23,12 @@ from uuid import UUID
 from rq import Retry, get_current_job
 from rq.decorators import job
 
+import re
+
 from extralit_server.api.schemas.v1.document.metadata import DocumentProcessingMetadata
 from extralit_server.contexts import files
 from extralit_server.contexts.document.analysis import PDFOCRLayerDetector
+from extralit_server.contexts.document.chunker import chunk_text
 from extralit_server.contexts.document.margin import PDFAnalyzer
 from extralit_server.contexts.document.preprocessing import PDFPreprocessingSettings, PDFPreprocessor
 from extralit_server.database import AsyncSessionLocal
@@ -189,3 +192,101 @@ async def analysis_and_preprocess_job(
         current_job.meta["error"] = str(e)
         current_job.save_meta()
         raise
+
+
+@job(queue=DEFAULT_QUEUE, connection=REDIS_CONNECTION, timeout=600, retry=Retry(max=3, interval=[10, 30, 60]))
+async def process_text_extraction_result_job(document_id: UUID, extraction_result: dict) -> dict[str, Any]:
+    """Process text-extraction JSON, chunk text with chonkie, and persist to DB.
+
+    Accepts the JSON result produced by an external OCR / text-extraction
+    worker (e.g. ``extralit_ocr.jobs.pymupdf_to_markdown_job``).  The
+    ``extraction_result`` dict may have one of these shapes:
+
+    * ``{"markdown": "..."}``
+    * ``{"text": "..."}``
+    * Marker-style ``{"pages": [{"blocks": [{"text"|"content"|"markdown": ...}]}]}``
+
+    Steps
+    -----
+    1. Extract plain text from whichever JSON shape is provided.
+    2. Create text chunks using **chonkie** ``RecursiveChunker``
+       (via :func:`~extralit_server.contexts.document.chunker.chunk_text`).
+    3. Persist the extracted text **and** chunks into
+       ``documents.metadata_`` → ``text_extraction_metadata`` in the DB.
+    """
+    current_job = get_current_job()
+    if current_job is None:
+        raise Exception("No current job found")
+
+    current_job.meta.update({"document_id": str(document_id), "workflow_step": "process_text_extraction"})
+    current_job.save_meta()
+
+    try:
+        text = _extract_text_from_result(extraction_result)
+
+        # Chunk the text using chonkie RecursiveChunker
+        chunks = chunk_text(text or "")
+
+        # Persist text + chunks into document metadata in the database
+        async with AsyncSessionLocal() as db:
+            document = await db.get(Document, document_id)
+            if document:
+                if document.metadata_ is None:
+                    document.metadata_ = DocumentProcessingMetadata().model_dump()
+
+                metadata = DocumentProcessingMetadata(**document.metadata_)
+                metadata.update_text_extraction_results(
+                    text=text or "",
+                    chunks=chunks,
+                    extraction_method="external_ocr",
+                )
+                document.metadata_ = metadata.model_dump()
+                await db.commit()
+
+        current_job.meta["chunks_count"] = len(chunks)
+        current_job.save_meta()
+
+        return {"document_id": str(document_id), "chunks_count": len(chunks)}
+
+    except Exception as e:
+        _LOGGER.error(f"Error processing text extraction for document {document_id}: {e}")
+        current_job.meta["error"] = str(e)
+        current_job.save_meta()
+        raise
+
+
+def _extract_text_from_result(extraction_result: dict) -> str:
+    """Pull plain text out of the various JSON shapes produced by OCR workers."""
+    if not extraction_result:
+        return ""
+
+    # Direct string fields
+    for key in ("markdown", "text", "content", "value"):
+        val = extraction_result.get(key)
+        if isinstance(val, str):
+            return val
+
+    # Marker-style pages → blocks
+    if "pages" in extraction_result and isinstance(extraction_result["pages"], list):
+        parts: list[str] = []
+        for page in extraction_result["pages"]:
+            blocks = page.get("blocks", []) if isinstance(page, dict) else []
+            for block in blocks:
+                if not isinstance(block, dict):
+                    continue
+                content = (
+                    block.get("markdown")
+                    or block.get("text")
+                    or block.get("content")
+                    or block.get("html")
+                    or ""
+                )
+                # Strip basic HTML tags if present
+                if content and "<" in content and ">" in content:
+                    content = re.sub(r"<[^>]+>", "", content)
+                if content:
+                    parts.append(content)
+        return "\n\n".join(parts)
+
+    # Absolute fallback
+    return str(extraction_result)

--- a/extralit-server/src/extralit_server/workflows/documents.py
+++ b/extralit-server/src/extralit_server/workflows/documents.py
@@ -19,7 +19,7 @@ from uuid import UUID, uuid4
 from rq.group import Group
 
 from extralit_server.database import AsyncSessionLocal
-from extralit_server.jobs.document_jobs import analysis_and_preprocess_job
+from extralit_server.jobs.document_jobs import analysis_and_preprocess_job, process_text_extraction_result_job
 from extralit_server.jobs.queues import DEFAULT_QUEUE, OCR_QUEUE, REDIS_CONNECTION
 from extralit_server.models.database import DocumentWorkflow
 
@@ -92,6 +92,12 @@ async def create_document_workflow(
 
     group.enqueue_many(queue=DEFAULT_QUEUE, job_datas=[analysis_job_data])
     group.enqueue_many(queue=OCR_QUEUE, job_datas=[text_extraction_job_data])
+
+    # Step 5: Chunking job — runs after text extraction completes.
+    # `process_text_extraction_result_job` is invoked with the OCR result
+    # (the dict returned by pymupdf_to_markdown_job) once that job finishes.
+    # Wiring via RQ Callback or a dependent enqueue is done by the caller
+    # that has access to the text-extraction result.
 
     # Step 6: Future table extraction job (conditional based on analysis results)
     # This will be added when table extraction is implemented

--- a/extralit-server/tests/unit/contexts/document/__init__.py
+++ b/extralit-server/tests/unit/contexts/document/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2024-present, Extralit Labs, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/extralit-server/tests/unit/contexts/document/test_chunker.py
+++ b/extralit-server/tests/unit/contexts/document/test_chunker.py
@@ -83,3 +83,36 @@ class TestChunkText:
         chunks_large = chunk_text(text, chunk_size=256)
         # Smaller chunk size ⇒ more chunks
         assert len(chunks_small) > len(chunks_large)
+
+    def test_table_header_and_body_are_merged(self):
+        text = (
+            "Table 2  Evaluation of the association between different genotypes of L119F-GSTe2 and the longevity "
+            "of exposed mosquitoes\n\n"
+            "Genotypes\n\nRR vs. SS\n\nRR vs. RS\n\nRS vs. SS\n\nR vs. S\n\n"
+            "(D2-D5)\n\n(D6-D10)\n\nOR\n\n95% CI\n\nP\n\n"
+            "2.6\n\n1.01-2.83\n\n0.02*\n\n"
+            "3.04\n\n1.10-2.72\n\n0.004*\n\n"
+            "6.47\n\n1.69-5.27\n\n< 0.0001*\n"
+        )
+
+        # Force base chunking to split, then verify table-aware merge rejoins it.
+        chunks = chunk_text(text, chunk_size=160, merge_table_chunks=True)
+
+        assert len(chunks) == 1
+        assert "Table 2" in chunks[0]["text"]
+        assert "0.004*" in chunks[0]["text"]
+
+    def test_table_merge_can_be_disabled(self):
+        text = (
+            "Table 2  Evaluation of the association between different genotypes of L119F-GSTe2 and the longevity "
+            "of exposed mosquitoes\n\n"
+            "Genotypes\n\nRR vs. SS\n\nRR vs. RS\n\nRS vs. SS\n\nR vs. S\n\n"
+            "(D2-D5)\n\n(D6-D10)\n\nOR\n\n95% CI\n\nP\n\n"
+            "2.6\n\n1.01-2.83\n\n0.02*\n\n"
+            "3.04\n\n1.10-2.72\n\n0.004*\n\n"
+            "6.47\n\n1.69-5.27\n\n< 0.0001*\n"
+        )
+
+        chunks = chunk_text(text, chunk_size=160, merge_table_chunks=False)
+
+        assert len(chunks) > 1

--- a/extralit-server/tests/unit/contexts/document/test_chunker.py
+++ b/extralit-server/tests/unit/contexts/document/test_chunker.py
@@ -1,0 +1,85 @@
+# Copyright 2024-present, Extralit Labs, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the chonkie-based text chunker."""
+
+import pytest
+
+from extralit_server.contexts.document.chunker import chunk_text
+
+
+class TestChunkText:
+    """Tests for chunk_text using chonkie RecursiveChunker."""
+
+    def test_empty_string_returns_empty(self):
+        assert chunk_text("") == []
+
+    def test_whitespace_only_returns_empty(self):
+        assert chunk_text("   \n\t  ") == []
+
+    def test_short_text_single_chunk(self):
+        text = "Hello world. This is a short sentence."
+        chunks = chunk_text(text, chunk_size=512)
+        assert len(chunks) >= 1
+        # The full text should appear in the chunk(s)
+        combined = " ".join(c["text"] for c in chunks)
+        assert "Hello world" in combined
+
+    def test_chunk_dict_keys(self):
+        text = "Some sample text for testing the chunker output format."
+        chunks = chunk_text(text, chunk_size=512)
+        assert len(chunks) >= 1
+        for chunk in chunks:
+            assert "text" in chunk
+            assert "start_index" in chunk
+            assert "end_index" in chunk
+            assert "token_count" in chunk
+            assert isinstance(chunk["text"], str)
+            assert isinstance(chunk["start_index"], int)
+            assert isinstance(chunk["end_index"], int)
+            assert isinstance(chunk["token_count"], int)
+
+    def test_long_text_produces_multiple_chunks(self):
+        # Create text that exceeds a single chunk
+        text = ("This is a paragraph of text. " * 200)
+        chunks = chunk_text(text, chunk_size=64)
+        assert len(chunks) > 1
+
+    def test_token_count_positive(self):
+        text = "The quick brown fox jumps over the lazy dog."
+        chunks = chunk_text(text, chunk_size=512)
+        for chunk in chunks:
+            assert chunk["token_count"] > 0
+
+    def test_start_end_index_ordering(self):
+        text = ("Sentence number one. " * 100)
+        chunks = chunk_text(text, chunk_size=32)
+        for chunk in chunks:
+            assert chunk["start_index"] < chunk["end_index"]
+
+    def test_chunks_are_json_serialisable(self):
+        import json
+
+        text = "A simple test for JSON serialisation."
+        chunks = chunk_text(text, chunk_size=512)
+        # Should not raise
+        serialised = json.dumps(chunks)
+        assert isinstance(serialised, str)
+
+    def test_custom_chunk_size(self):
+        text = ("Word " * 500)
+        chunks_small = chunk_text(text, chunk_size=32)
+        chunks_large = chunk_text(text, chunk_size=256)
+        # Smaller chunk size ⇒ more chunks
+        assert len(chunks_small) > len(chunks_large)

--- a/extralit-server/tests/unit/contexts/document/test_text_extraction.py
+++ b/extralit-server/tests/unit/contexts/document/test_text_extraction.py
@@ -1,0 +1,122 @@
+# Copyright 2024-present, Extralit Labs, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for TextExtractionMetadata with chunks and the RQ job helper."""
+
+import pytest
+
+from extralit_server.api.schemas.v1.document.metadata import (
+    ChunkMetadata,
+    DocumentProcessingMetadata,
+    TextExtractionMetadata,
+)
+from extralit_server.jobs.document_jobs import _extract_text_from_result
+
+
+# ---------------------------------------------------------------------------
+# ChunkMetadata / TextExtractionMetadata schema tests
+# ---------------------------------------------------------------------------
+
+
+class TestChunkMetadata:
+    def test_create_chunk_metadata(self):
+        cm = ChunkMetadata(text="hello", start_index=0, end_index=5, token_count=1)
+        assert cm.text == "hello"
+        assert cm.start_index == 0
+
+    def test_text_extraction_with_chunks(self):
+        chunks = [
+            ChunkMetadata(text="chunk1", start_index=0, end_index=6, token_count=1),
+            ChunkMetadata(text="chunk2", start_index=6, end_index=12, token_count=1),
+        ]
+        tem = TextExtractionMetadata(
+            markdown="chunk1chunk2",
+            extraction_method="external_ocr",
+            chunks=chunks,
+        )
+        assert len(tem.chunks) == 2
+        assert tem.chunks[0].text == "chunk1"
+
+    def test_text_extraction_chunks_default_none(self):
+        tem = TextExtractionMetadata(markdown="hi", extraction_method="ocr")
+        assert tem.chunks is None
+
+
+class TestUpdateTextExtractionResults:
+    def test_updates_metadata(self):
+        meta = DocumentProcessingMetadata()
+        chunks = [
+            {"text": "a", "start_index": 0, "end_index": 1, "token_count": 1},
+            {"text": "b", "start_index": 1, "end_index": 2, "token_count": 1},
+        ]
+        meta.update_text_extraction_results(text="ab", chunks=chunks)
+        assert meta.text_extraction_metadata is not None
+        assert meta.text_extraction_metadata.markdown == "ab"
+        assert len(meta.text_extraction_metadata.chunks) == 2
+        assert meta.text_extraction_metadata.extraction_method == "external_ocr"
+
+    def test_roundtrip_serialisation(self):
+        meta = DocumentProcessingMetadata()
+        chunks = [{"text": "x", "start_index": 0, "end_index": 1, "token_count": 1}]
+        meta.update_text_extraction_results(text="x", chunks=chunks)
+        dumped = meta.model_dump()
+        restored = DocumentProcessingMetadata(**dumped)
+        assert restored.text_extraction_metadata.chunks[0].text == "x"
+
+
+# ---------------------------------------------------------------------------
+# _extract_text_from_result helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTextFromResult:
+    def test_empty_dict(self):
+        assert _extract_text_from_result({}) == ""
+
+    def test_none(self):
+        assert _extract_text_from_result(None) == ""
+
+    def test_markdown_key(self):
+        assert _extract_text_from_result({"markdown": "# Title"}) == "# Title"
+
+    def test_text_key(self):
+        assert _extract_text_from_result({"text": "hello"}) == "hello"
+
+    def test_content_key(self):
+        assert _extract_text_from_result({"content": "body"}) == "body"
+
+    def test_pages_blocks_text(self):
+        result = {
+            "pages": [
+                {"blocks": [{"text": "block1"}, {"text": "block2"}]},
+                {"blocks": [{"text": "block3"}]},
+            ]
+        }
+        text = _extract_text_from_result(result)
+        assert "block1" in text
+        assert "block2" in text
+        assert "block3" in text
+
+    def test_pages_blocks_html_stripped(self):
+        result = {
+            "pages": [{"blocks": [{"html": "<p>hello</p>"}]}]
+        }
+        text = _extract_text_from_result(result)
+        assert "<p>" not in text
+        assert "hello" in text
+
+    def test_fallback_stringifies(self):
+        result = {"unknown_key": 42}
+        text = _extract_text_from_result(result)
+        assert "42" in text


### PR DESCRIPTION
[Feature] Implement recursive chunking with chonkie and persist to db

## Description

This PR adds a text chunking pipeline to the document processing workflow. It introduces an RQ job that takes the JSON output from the OCR/text-extraction worker, extracts plain text from various JSON shapes (markdown, text, Marker-style pages→blocks), chunks it using chonkie's `RecursiveChunker`, and persists both the extracted text and chunks into `documents.metadata_` in the database.

Key changes:
- **`chunker.py`** — Rewrote to use `chonkie.RecursiveChunker` (default 512-token chunks) instead of a custom naive whitespace splitter.
- **`metadata.py`** — Added `ChunkMetadata` model and `chunks` field to `TextExtractionMetadata`; added `update_text_extraction_results()` helper on `DocumentProcessingMetadata`.
- **`document_jobs.py`** — Added `process_text_extraction_result_job` RQ job and `_extract_text_from_result()` helper that handles multiple OCR JSON formats.
- **`preprocessing.py`** — Removed stale chunking logic (`chunk_pdf()` method) and unused imports.
- **`chunk_store.py`** — Deleted. Chunks are persisted to DB, not stored in a process-local in-memory dict.
- **`documents.py` (workflow)** — Imported the new job; ready to be wired via RQ Callback when text-extraction completes.
- **`pyproject.toml`** — Added `chonkie>=1.0.2` dependency.

## Related Tickets & Documents

Assigned by @JonnyTran via chat

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Steps to QA

1. Install dependencies: `pip install -e ".[dev]"` from `extralit-server/`.
2. Run the new unit tests:
   ```bash
   python -m pytest tests/unit/contexts/document/ -v --noconftest

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added/updated documentations?

- [ ] Yes
- [X] No, and this is why: This is an internal backend pipeline addition. API-facing docs are not affected since chunks are stored in the existing documents.metadata_ JSON column with no new endpoints.
- [ ] I need help with writing docs

## Checklist
- [X] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
