### PR TITLE
ci: actions lint and update GitHub Actions workflows

### DIFF
--- a/.github/workflows/close-inactive-issues-bot.yml
+++ b/.github/workflows/close-inactive-issues-bot.yml
@@ -14,7 +14,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@v10
         with:
           days-before-issue-stale: 90
           days-before-issue-close: 30

--- a/.github/workflows/extralit-frontend.teardown-all-pr-environments.yml
+++ b/.github/workflows/extralit-frontend.teardown-all-pr-environments.yml
@@ -19,13 +19,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.GOOGLE_CLOUD_WIP }}
           service_account: ${{ secrets.GOOGLE_CLOUD_SERVICE_ACCOUNT }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           version: ">= 435.0.0"
 

--- a/.github/workflows/extralit-frontend.teardown-pr-environment.yml
+++ b/.github/workflows/extralit-frontend.teardown-pr-environment.yml
@@ -20,13 +20,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.GOOGLE_CLOUD_WIP }}
           service_account: ${{ secrets.GOOGLE_CLOUD_SERVICE_ACCOUNT }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           version: ">= 435.0.0"
 

--- a/.github/workflows/extralit-server.build-docker-images.yml
+++ b/.github/workflows/extralit-server.build-docker-images.yml
@@ -105,6 +105,13 @@ jobs:
           name: extralit-server
           path: extralit-server/docker/server/dist
 
+      # Only `labels` is consumed downstream; tags come from IMAGE_TAG, not from this step.
+      - name: Extract OCI image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.SERVER_DOCKER_IMAGE }}
+
       - name: Build and push `extralit-server` image
         uses: docker/build-push-action@v5
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,11 @@ repos:
         args: [--fix]
       - id: ruff-format
 
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.9
+    hooks:
+      - id: actionlint
+
   ##############################################################################
   # extralit SDK specific hooks
   ##############################################################################


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows and the pre-commit configuration to use newer versions of key actions and introduces a new linting hook. The main focus is on keeping dependencies up to date for better reliability, security, and compatibility, as well as improving CI/CD hygiene.

**GitHub Actions workflow updates:**

* Updated the `actions/stale` action from version 5 to version 10 in `.github/workflows/close-inactive-issues-bot.yml` to ensure continued support and benefit from improvements.
* Upgraded `google-github-actions/auth` and `google-github-actions/setup-gcloud` from v1 to v2 in both `.github/workflows/extralit-frontend.teardown-all-pr-environments.yml` and `.github/workflows/extralit-frontend.teardown-pr-environment.yml` for improved authentication and gcloud setup. [[1]](diffhunk://#diff-d74aef7f4d1590f4ee35defdfb341dec8af99d349d5136a7596e8db74fe17421L22-R28) [[2]](diffhunk://#diff-46d9628a391c0b70c1137c78c492f4d0aa165cb518b8edf8240c0f088e915019L23-R29)
* Added a new step using `docker/metadata-action@v5` to extract OCI image metadata in `.github/workflows/extralit-server.build-docker-images.yml`, which helps with downstream image labeling and metadata management.

**Pre-commit configuration improvements:**

* Introduced the `actionlint` hook (via `rhysd/actionlint` at v1.7.9) in `.pre-commit-config.yaml` to lint GitHub Actions workflows, helping catch syntax and usage errors early.