### PR TITLE
[Optimization] Skip the server suite on frontend-only pushes to a PR

### DIFF
--- a/.github/workflows/extralit-server.yml
+++ b/.github/workflows/extralit-server.yml
@@ -30,9 +30,46 @@ permissions:
   id-token: write
 
 jobs:
+  # `pull_request` path filters match the PR's cumulative diff, so once a PR touches the server
+  # every later push re-runs the ~6min suite even if it only moved frontend files. Re-filter the
+  # incremental push delta here; anything we can't resolve falls through to running the suite.
+  changes:
+    name: Detect server changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      server: ${{ steps.filter.outputs.server }}
+    steps:
+      - id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.event.after }}
+        run: |
+          set -uo pipefail
+          run_suite() { echo "server=true" >> "$GITHUB_OUTPUT"; exit 0; }
+
+          # Only `synchronize` carries a previous head to diff against; `opened`/`reopened`/
+          # `push`/`workflow_dispatch` always run.
+          [[ "${{ github.event_name }}/${{ github.event.action }}" == "pull_request/synchronize" ]] || run_suite
+
+          # A force-push can leave `before` unreachable, which fails the compare.
+          compare=$(gh api "repos/${{ github.repository }}/compare/$BEFORE...$AFTER") || run_suite
+          changed=$(jq -r '.files[].filename' <<<"$compare")
+          [[ -n "$changed" && $(wc -l <<<"$changed") -lt 300 ]] || run_suite
+
+          echo "$changed" | sed 's/^/  /'
+          if grep -qE '^(extralit-server/|openapi/v1\.json$|\.github/)' <<<"$changed"; then
+            run_suite
+          fi
+          echo "server=false" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build `extralit-server` package
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.server != 'false' }}
 
     defaults:
       run:

--- a/.github/workflows/extralit-server.yml
+++ b/.github/workflows/extralit-server.yml
@@ -56,9 +56,7 @@ jobs:
 
           # A force-push can leave `before` unreachable, which fails the compare.
           compare=$(gh api "repos/${{ github.repository }}/compare/$BEFORE...$AFTER") || run_suite
-          # A rename reports only its destination in `filename`; without `previous_filename` a
-          # file moved *out* of extralit-server/ would read as a non-server change.
-          changed=$(jq -r '.files[] | .filename, (.previous_filename // empty)' <<<"$compare")
+          changed=$(jq -r '.files[].filename' <<<"$compare")
           [[ -n "$changed" && $(wc -l <<<"$changed") -lt 300 ]] || run_suite
 
           echo "$changed" | sed 's/^/  /'

--- a/.github/workflows/extralit-server.yml
+++ b/.github/workflows/extralit-server.yml
@@ -56,7 +56,9 @@ jobs:
 
           # A force-push can leave `before` unreachable, which fails the compare.
           compare=$(gh api "repos/${{ github.repository }}/compare/$BEFORE...$AFTER") || run_suite
-          changed=$(jq -r '.files[].filename' <<<"$compare")
+          # A rename reports only its destination in `filename`; without `previous_filename` a
+          # file moved *out* of extralit-server/ would read as a non-server change.
+          changed=$(jq -r '.files[] | .filename, (.previous_filename // empty)' <<<"$compare")
           [[ -n "$changed" && $(wc -l <<<"$changed") -lt 300 ]] || run_suite
 
           echo "$changed" | sed 's/^/  /'


### PR DESCRIPTION
## Description

`pull_request` path filters match the PR's **cumulative diff against the base**, not the
incremental push. So once a PR touches `extralit-server/**`, every later push re-runs the full
~6.5min server suite — even a push that only moves frontend files. This happened on #244: a
one-file `extralit-frontend/types/generated/api.d.ts` push re-triggered the whole server build.

This adds a `changes` gate job that re-filters the *incremental* push delta and skips the build
when nothing server-relevant moved. It uses the compare API rather than git, so no checkout is
needed and the gate costs a few seconds.

Where the 388s actually goes, for reference (recent green run):

| step | time |
|---|---|
| Initialize containers (ES/PG) | 76s |
| Run tests | 275s |
| Download frontend statics | 6s |
| Build package | 2s |

**Fail-open by construction.** Every path that can't resolve a clean answer runs the suite:

- non-`synchronize` events (`opened`, `reopened`, `push`, `workflow_dispatch`)
- a force-pushed `before` sha that's no longer reachable
- a compare response truncated at the API's 300-file cap
- the gate job itself failing — that's what `if: ${{ !cancelled() && needs.changes.outputs.server != 'false' }}`
  buys. A plain `== 'true'` would silently skip the tests if the gate died.

`.github/` counts as server-relevant, so this PR runs the full suite itself — which is the only
way to exercise the changed workflow.

No branch-protection change needed: the workflow still runs, and a conditionally-skipped job
reports `skipping` without blocking (same as `Build docker images` / `Publish Release` do today).
The blocking case is only a workflow that never runs at all.

## Related Tickets & Documents

Follow-up from #244.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Steps to QA

The gate logic was run locally against real commit ranges from #244:

| range | expected | got |
|---|---|---|
| `5fd48a6f9...251c44e93` (frontend-only push) | `server=false` | `server=false` |
| `a86ae3190...5fd48a6f9` (touches server) | `server=true` | `server=true` |
| bogus/unreachable `before` sha | `server=true` | `server=true` |

`actionlint` (pre-commit, includes shellcheck on `run:` blocks) passes.

Not verified end-to-end on GitHub — that needs a real frontend-only push to a live PR, which
only happens once this is merged. First mixed PR after merge is the real test.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: workflow gating isn't unit-testable in this repo; verified by running
      the gate script against real shas (above) and by actionlint.
- [ ] I need help with writing tests

## Added/updated documentations?

- [ ] Yes
- [x] No, and this is why: the rationale lives in a comment above the gate job, where anyone
      editing the path filters will see it.
- [ ] I need help with writing docs

## Checklist
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)

## Known follow-up

`extralit.yml` (the SDK, `build (3.13)`) has the identical problem and also re-ran on that
frontend-only push. Left out of scope here; worth either mirroring the gate or factoring it into
a reusable workflow.
