### PR TITLE
fix(server): restore put_document_file's workspace_name parameter

### DIFF
--- a/extralit-server/src/extralit_server/contexts/files.py
+++ b/extralit-server/src/extralit_server/contexts/files.py
@@ -383,7 +383,7 @@ async def delete_document_artifacts(storage: ObjectStorage, workspace: str, docu
 
 async def put_document_file(
     storage: ObjectStorage,
-    workspace: str,
+    workspace_name: str,
     document_id: UUID,
     file_data: bytes,
     filename: str,
@@ -399,7 +399,7 @@ async def put_document_file(
     object_path = get_pdf_s3_object_path(document_id)
 
     try:
-        existing_files = await list_objects(storage, workspace, prefix=object_path, recursive=False)
+        existing_files = await list_objects(storage, workspace_name, prefix=object_path, recursive=False)
 
         should_upload = True
         if existing_files.objects:
@@ -412,9 +412,9 @@ async def put_document_file(
                 should_upload = False
 
         if should_upload:
-            await _put(storage, workspace, object_path, file_data, content_type, metadata)
+            await _put(storage, workspace_name, object_path, file_data, content_type, metadata)
 
-            return get_proxy_document_url(workspace, object_path)
+            return get_proxy_document_url(workspace_name, object_path)
 
         return None
 

--- a/extralit-server/tests/unit/contexts/test_files_store.py
+++ b/extralit-server/tests/unit/contexts/test_files_store.py
@@ -178,7 +178,13 @@ class TestPutDocumentFile:
     async def test_the_first_upload_returns_a_proxy_url(self, storage):
         from uuid import uuid4
 
-        url = await files.put_document_file(storage, WORKSPACE, uuid4(), b"%PDF-1.4", "a.pdf")
+        url = await files.put_document_file(
+            storage=storage,
+            workspace_name=WORKSPACE,
+            document_id=uuid4(),
+            file_data=b"%PDF-1.4",
+            filename="a.pdf",
+        )
 
         assert url is not None
         assert url.startswith(f"/api/v1/file/{WORKSPACE}/pdf/")


### PR DESCRIPTION
Blocks a 0.7.2 release. `v0.7.1` was cut, failed its integration suite, and was never published — this is the fix that makes it publishable.

## The break

The obstore refactor (#244/#246) renamed `put_document_file`'s second parameter to `workspace` but left both callers passing `workspace_name=`:

| Caller | Path |
|---|---|
| `api/handlers/v1/documents.py:82` | `POST /api/v1/documents` |
| `contexts/imports.py:432` | bulk import |

Every document upload raised `TypeError: put_document_file() got an unexpected keyword argument 'workspace_name'` and returned a 500. On `v0.7.1`:

```
FAILED tests/integration/test_workspace_documents.py::TestWorkspaceDocuments::test_add_document_with_file
  InternalServerError ... "message":"put_document_file() got an unexpected keyword argument 'workspace_name'"
```

## Why the unit suite missed it

`tests/unit/contexts/test_files_store.py:181` called it **positionally**, so the signature could drift from its callers without any unit test noticing. Integration caught it, but integration doesn't gate most PRs. That test now calls by keyword — the change that makes this class of break visible where it needs to be.

## Which side to fix

I renamed the parameter rather than the two call sites. Worth stating the tradeoff, because the other direction is defensible:

- **For renaming the parameter (this PR):** `put_document_file` is exported and its `v0.7.0` signature took `workspace_name`. Renaming it back keeps the public signature stable, so no out-of-repo caller has to change across the 0.7.x line.
- **Against:** `contexts/files.py` otherwise uses `workspace` universally — `_put`, `put_object`, `get_object`, `delete_object`, `list_objects`, `delete_workspace_objects`, `delete_document_artifacts` all do, and the module now contains exactly one `workspace_name`. By the module's own convention the *callers* were the outliers.

Happy to flip it to updating the two call sites if the reviewer prefers internal consistency over signature stability.

## Verification

An AST scan of every keyword call against `contexts/files.py` signatures, run on both revisions, confirms the fix is complete and that this was the only such mismatch:

```
PRE-FIX (v0.7.1):
  contexts/imports.py:432                put_document_file(... workspace_name=...)
  api/handlers/v1/documents.py:82        put_document_file(... workspace_name=...)
POST-FIX:
  (no mismatches)
```

`tests/unit`: **1971 passed**, 42 skipped. Three failures in `tests/unit/security` (`test_jwt`, `test_default_security_settings`) reproduce identically on unmodified `main` in the same environment and are unrelated — CI is green on `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when uploading document files to a workspace, ensuring existing files are checked and uploaded content is associated with the correct workspace.
  * Preserved existing duplicate-file handling and error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->